### PR TITLE
cross run finding classification

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -643,20 +643,21 @@ export async function runEngine(
     // Generate reports with per-node attribution
     const areaResults = buildAreaResults(ctx);
     if (memoryStore) {
-      // Capture pre-run history so classification reflects state before this run's findings are recorded.
+      // Classify against the pre-run snapshot before this run mutates memory history.
       const preRunSnapshot = memoryStore.getSnapshot();
-      const preRunFindingHistory = structuredClone(preRunSnapshot.findingHistory);
-      const preRunFlakyPages = structuredClone(preRunSnapshot.flakyPages);
+      const findings = collectFindings(areaResults);
+      const includeResolved = remaining.length === 0;
+      ctx.crossRunClassification = classifyFindings(
+        findings,
+        preRunSnapshot.findingHistory,
+        preRunSnapshot.flakyPages,
+        { includeResolved }
+      );
 
       memoryStore.recordRunFindings(startTime.toISOString(), areaResults);
       memoryStore.recordObservedApiTraffic(startTime.toISOString(), trafficObserver.snapshot());
       memoryStore.recordNavigationSnapshot(config.targetUrl, ctx.graph);
       ctx.runMemory = memoryStore.getSummary(warmStartApplied, warmStartRestoredStateCount);
-      ctx.crossRunClassification = classifyFindings(
-        collectFindings(areaResults),
-        preRunFindingHistory,
-        preRunFlakyPages
-      );
     }
     writeReports(ctx, startTime, areaResults, remaining);
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -39,6 +39,8 @@ import {
   flushOwnedBrowserErrors,
 } from './engine/graph-ops.js';
 import { buildAreaResults, writeReports } from './engine/reports.js';
+import { classifyFindings } from './report/cross-run-classification.js';
+import { collectFindings } from './report/collector.js';
 import { executeFrontierItem } from './engine/execute-frontier-item.js';
 import type { WorkerSession } from './engine/worker-pool.js';
 import { scanRepository } from './adaptation/repo-scan.js';
@@ -641,10 +643,20 @@ export async function runEngine(
     // Generate reports with per-node attribution
     const areaResults = buildAreaResults(ctx);
     if (memoryStore) {
+      // Capture pre-run history so classification reflects state before this run's findings are recorded.
+      const preRunSnapshot = memoryStore.getSnapshot();
+      const preRunFindingHistory = structuredClone(preRunSnapshot.findingHistory);
+      const preRunFlakyPages = structuredClone(preRunSnapshot.flakyPages);
+
       memoryStore.recordRunFindings(startTime.toISOString(), areaResults);
       memoryStore.recordObservedApiTraffic(startTime.toISOString(), trafficObserver.snapshot());
       memoryStore.recordNavigationSnapshot(config.targetUrl, ctx.graph);
       ctx.runMemory = memoryStore.getSummary(warmStartApplied, warmStartRestoredStateCount);
+      ctx.crossRunClassification = classifyFindings(
+        collectFindings(areaResults),
+        preRunFindingHistory,
+        preRunFlakyPages
+      );
     }
     writeReports(ctx, startTime, areaResults, remaining);
 

--- a/src/engine/context.ts
+++ b/src/engine/context.ts
@@ -20,7 +20,7 @@ import type { BrowserErrorCollector } from '../browser-errors.js';
 import type { WorkerSession } from './worker-pool.js';
 import type { RepoHints } from '../adaptation/types.js';
 import type { MemoryStore } from '../memory/store.js';
-import type { RunMemoryMeta } from '../types.js';
+import type { CrossRunClassification, RunMemoryMeta } from '../types.js';
 import type { NetworkTrafficObserver } from '../network/traffic-observer.js';
 import type { ContractIndex } from '../spec/contract-index.js';
 import type { ApiRequestContextLike } from '../api/types.js';
@@ -58,6 +58,7 @@ export interface EngineContext {
   trafficObserver?: NetworkTrafficObserver;
   memoryStore?: MemoryStore;
   runMemory?: RunMemoryMeta;
+  crossRunClassification?: CrossRunClassification;
   createIsolatedApiRequestContext?: () => Promise<ApiRequestContextLike>;
   safetyGuard?: SafetyGuard;
   eventStream?: EngineEventEmitter;

--- a/src/engine/reports.ts
+++ b/src/engine/reports.ts
@@ -102,7 +102,8 @@ export function writeReports(
       warmStartEnabled: config.memory.enabled && config.memory.warmStart,
     },
     ctx.runMemory,
-    diffSummary
+    diffSummary,
+    ctx.crossRunClassification
   );
   const generatedTests = writeGeneratedPlaywrightTests(ctx.outputDir, runResult);
 

--- a/src/engine/reports.ts
+++ b/src/engine/reports.ts
@@ -80,30 +80,32 @@ export function writeReports(
       reason: `Not reached (priority: ${r.priority.toFixed(2)})`,
     })),
     remaining.length > 0,
-    blindSpots,
-    stateGraphMermaid,
     {
-      appDescription: config.appDescription,
-      models: { planner: config.models.planner, worker: config.models.worker },
-      concurrency: config.concurrency.workers,
-      budget: {
-        timeLimitSeconds: ctx.budget.globalTimeLimitSeconds,
-        maxStepsPerTask: ctx.budget.maxStepsPerTask,
-        maxStateNodes: ctx.budget.maxStateNodes,
+      blindSpots,
+      stateGraphMermaid,
+      runConfig: {
+        appDescription: config.appDescription,
+        models: { planner: config.models.planner, worker: config.models.worker },
+        concurrency: config.concurrency.workers,
+        budget: {
+          timeLimitSeconds: ctx.budget.globalTimeLimitSeconds,
+          maxStepsPerTask: ctx.budget.maxStepsPerTask,
+          maxStateNodes: ctx.budget.maxStateNodes,
+        },
+        checkpointInterval: config.checkpoint.intervalTasks,
+        autoCaptureEnabled:
+          config.autoCapture.consoleErrors ||
+          config.autoCapture.consoleWarnings ||
+          config.autoCapture.networkErrors,
+        llmPlannerEnabled: hasLLMApiKey(config.models.planner),
+        memoryEnabled: config.memory.enabled,
+        visualRegressionEnabled: config.visualRegression.enabled,
+        warmStartEnabled: config.memory.enabled && config.memory.warmStart,
       },
-      checkpointInterval: config.checkpoint.intervalTasks,
-      autoCaptureEnabled:
-        config.autoCapture.consoleErrors ||
-        config.autoCapture.consoleWarnings ||
-        config.autoCapture.networkErrors,
-      llmPlannerEnabled: hasLLMApiKey(config.models.planner),
-      memoryEnabled: config.memory.enabled,
-      visualRegressionEnabled: config.visualRegression.enabled,
-      warmStartEnabled: config.memory.enabled && config.memory.warmStart,
-    },
-    ctx.runMemory,
-    diffSummary,
-    ctx.crossRunClassification
+      runMemory: ctx.runMemory,
+      diffSummary,
+      crossRunClassification: ctx.crossRunClassification,
+    }
   );
   const generatedTests = writeGeneratedPlaywrightTests(ctx.outputDir, runResult);
 

--- a/src/report/collector.test.ts
+++ b/src/report/collector.test.ts
@@ -139,36 +139,32 @@ describe('buildRunResult', () => {
     const blindSpots: BlindSpot[] = [
       { summary: 'Unreachable modal', reason: 'state-unreachable', severity: 'medium' },
     ];
-    const result = buildRunResult('https://example.com', new Date(), [], [], false, blindSpots);
+    const result = buildRunResult('https://example.com', new Date(), [], [], false, { blindSpots });
     expect(result.blindSpots).toHaveLength(1);
     expect(result.blindSpots[0].summary).toBe('Unreachable modal');
   });
 
   it('includes stateGraphMermaid when provided', () => {
-    const result = buildRunResult(
-      'https://example.com',
-      new Date(),
-      [],
-      [],
-      false,
-      [],
-      'graph TD\n  A --> B'
-    );
+    const result = buildRunResult('https://example.com', new Date(), [], [], false, {
+      stateGraphMermaid: 'graph TD\n  A --> B',
+    });
     expect(result.stateGraphMermaid).toBe('graph TD\n  A --> B');
   });
 
   it('includes runConfig when provided', () => {
-    const result = buildRunResult('https://example.com', new Date(), [], [], false, [], undefined, {
-      appDescription: 'Test app',
-      models: { planner: 'claude-sonnet', worker: 'claude-haiku' },
-      concurrency: 2,
-      budget: { timeLimitSeconds: 900, maxStepsPerTask: 40, maxStateNodes: 50 },
-      checkpointInterval: 5,
-      autoCaptureEnabled: true,
-      llmPlannerEnabled: false,
-      memoryEnabled: true,
-      visualRegressionEnabled: true,
-      warmStartEnabled: true,
+    const result = buildRunResult('https://example.com', new Date(), [], [], false, {
+      runConfig: {
+        appDescription: 'Test app',
+        models: { planner: 'claude-sonnet', worker: 'claude-haiku' },
+        concurrency: 2,
+        budget: { timeLimitSeconds: 900, maxStepsPerTask: 40, maxStateNodes: 50 },
+        checkpointInterval: 5,
+        autoCaptureEnabled: true,
+        llmPlannerEnabled: false,
+        memoryEnabled: true,
+        visualRegressionEnabled: true,
+        warmStartEnabled: true,
+      },
     });
     expect(result.runConfig?.concurrency).toBe(2);
     expect(result.runConfig?.llmPlannerEnabled).toBe(false);

--- a/src/report/collector.ts
+++ b/src/report/collector.ts
@@ -4,6 +4,7 @@
 import type {
   AreaResult,
   BlindSpot,
+  CrossRunClassification,
   DiffSummary,
   Finding,
   FindingSeverity,
@@ -140,7 +141,8 @@ export function buildRunResult(
   stateGraphMermaid?: string,
   runConfig?: RunConfigMeta,
   runMemory?: RunMemoryMeta,
-  diffSummary?: DiffSummary
+  diffSummary?: DiffSummary,
+  crossRunClassification?: CrossRunClassification
 ): RunResult {
   return {
     targetUrl,
@@ -154,5 +156,6 @@ export function buildRunResult(
     runConfig,
     runMemory,
     diffSummary,
+    crossRunClassification,
   };
 }

--- a/src/report/collector.ts
+++ b/src/report/collector.ts
@@ -137,13 +137,24 @@ export function buildRunResult(
   areaResults: AreaResult[],
   unexploredAreas: Array<{ name: string; reason: string }>,
   partial: boolean,
-  blindSpots: BlindSpot[] = [],
-  stateGraphMermaid?: string,
-  runConfig?: RunConfigMeta,
-  runMemory?: RunMemoryMeta,
-  diffSummary?: DiffSummary,
-  crossRunClassification?: CrossRunClassification
+  options: {
+    blindSpots?: BlindSpot[];
+    stateGraphMermaid?: string;
+    runConfig?: RunConfigMeta;
+    runMemory?: RunMemoryMeta;
+    diffSummary?: DiffSummary;
+    crossRunClassification?: CrossRunClassification;
+  } = {}
 ): RunResult {
+  const {
+    blindSpots = [],
+    stateGraphMermaid,
+    runConfig,
+    runMemory,
+    diffSummary,
+    crossRunClassification,
+  } = options;
+
   return {
     targetUrl,
     startTime,

--- a/src/report/cross-run-classification.test.ts
+++ b/src/report/cross-run-classification.test.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 Alex Rambasek
+
+import { describe, expect, it } from 'vitest';
+import { classifyFindings } from './cross-run-classification.js';
+import { buildFindingGroupKey } from './collector.js';
+import type { Finding } from '../types.js';
+import type { HistoricalFindingRecord, HistoricalFlakyPageRecord } from '../memory/types.js';
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  const base: Finding = {
+    id: 'BUG-001',
+    ref: 'fid-1',
+    category: 'Bug',
+    severity: 'Major',
+    area: 'Dashboard',
+    title: 'Button does nothing',
+    stepsToReproduce: ['Open page', 'Click button'],
+    expected: 'Dialog opens',
+    actual: 'Nothing happens',
+    occurrenceCount: 1,
+    impactedAreas: ['Dashboard'],
+    occurrences: [
+      {
+        area: 'Dashboard',
+        route: 'https://example.com/dash',
+        evidenceIds: [],
+        ref: 'fid-1',
+      },
+    ],
+    ...overrides,
+  };
+  return base;
+}
+
+function signatureFor(finding: Finding): string {
+  return buildFindingGroupKey(finding);
+}
+
+function makeRecord(
+  finding: Finding,
+  overrides: Partial<HistoricalFindingRecord> = {}
+): HistoricalFindingRecord {
+  return {
+    signature: signatureFor(finding),
+    title: finding.title,
+    category: finding.category,
+    severity: finding.severity,
+    firstSeenAt: '2026-01-01T00:00:00.000Z',
+    lastSeenAt: '2026-02-01T00:00:00.000Z',
+    runCount: 2,
+    occurrenceCount: 2,
+    recentRoutes: ['/dash'],
+    suppressed: false,
+    ...overrides,
+  };
+}
+
+describe('classifyFindings', () => {
+  it('marks findings as new when memory history is empty', () => {
+    const finding = makeFinding();
+    const result = classifyFindings([finding], {});
+
+    expect(result.summary).toEqual({ new: 1, recurring: 0, resolved: 0, flaky: 0, suppressed: 0 });
+    expect(result.byFindingId[finding.id].status).toBe('new');
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('marks findings as recurring when signature already exists in history', () => {
+    const finding = makeFinding();
+    const record = makeRecord(finding);
+    const result = classifyFindings([finding], { [record.signature]: record });
+
+    expect(result.summary.recurring).toBe(1);
+    expect(result.byFindingId[finding.id].status).toBe('recurring');
+    expect(result.byFindingId[finding.id].firstSeenAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(result.byFindingId[finding.id].runCount).toBe(2);
+  });
+
+  it('marks findings as suppressed when history record is suppressed', () => {
+    const finding = makeFinding();
+    const record = makeRecord(finding, { suppressed: true, dismissalReason: 'false positive' });
+    const result = classifyFindings([finding], { [record.signature]: record });
+
+    expect(result.summary.suppressed).toBe(1);
+    expect(result.byFindingId[finding.id].status).toBe('suppressed');
+    expect(result.byFindingId[finding.id].dismissalReason).toBe('false positive');
+  });
+
+  it('marks findings as flaky when their route matches a flaky page', () => {
+    const finding = makeFinding();
+    const flakyPages: HistoricalFlakyPageRecord[] = [
+      {
+        key: 'k1',
+        route: '/dash',
+        note: 'intermittent',
+        source: 'visual-regression',
+        firstSeenAt: '2026-01-01T00:00:00.000Z',
+        lastSeenAt: '2026-02-01T00:00:00.000Z',
+        count: 3,
+      },
+    ];
+    const result = classifyFindings([finding], {}, flakyPages);
+
+    expect(result.summary.flaky).toBe(1);
+    expect(result.byFindingId[finding.id].status).toBe('flaky');
+  });
+
+  it('suppressed status wins over flaky', () => {
+    const finding = makeFinding();
+    const record = makeRecord(finding, { suppressed: true });
+    const flakyPages: HistoricalFlakyPageRecord[] = [
+      {
+        key: 'k1',
+        route: '/dash',
+        note: 'intermittent',
+        source: 'manual',
+        firstSeenAt: '2026-01-01T00:00:00.000Z',
+        lastSeenAt: '2026-02-01T00:00:00.000Z',
+        count: 1,
+      },
+    ];
+    const result = classifyFindings([finding], { [record.signature]: record }, flakyPages);
+
+    expect(result.byFindingId[finding.id].status).toBe('suppressed');
+  });
+
+  it('collects resolved findings from prior runs not present in the current set', () => {
+    const currentFinding = makeFinding();
+    const goneFinding = makeFinding({ title: 'Old finding that resolved' });
+    const goneRecord = makeRecord(goneFinding, {
+      firstSeenAt: '2025-12-01T00:00:00.000Z',
+      lastSeenAt: '2026-03-01T00:00:00.000Z',
+      runCount: 5,
+    });
+
+    const result = classifyFindings([currentFinding], { [goneRecord.signature]: goneRecord });
+
+    expect(result.summary.resolved).toBe(1);
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].title).toBe('Old finding that resolved');
+    expect(result.resolved[0].runCount).toBe(5);
+  });
+
+  it('does not count suppressed prior findings as resolved', () => {
+    const currentFinding = makeFinding();
+    const suppressedFinding = makeFinding({ title: 'Suppressed and gone' });
+    const suppressedRecord = makeRecord(suppressedFinding, { suppressed: true });
+
+    const result = classifyFindings([currentFinding], {
+      [suppressedRecord.signature]: suppressedRecord,
+    });
+
+    expect(result.summary.resolved).toBe(0);
+    expect(result.resolved).toEqual([]);
+  });
+});

--- a/src/report/cross-run-classification.test.ts
+++ b/src/report/cross-run-classification.test.ts
@@ -154,4 +154,33 @@ describe('classifyFindings', () => {
     expect(result.summary.resolved).toBe(0);
     expect(result.resolved).toEqual([]);
   });
+
+  it('does not count dismissed prior findings as resolved', () => {
+    const currentFinding = makeFinding();
+    const dismissedFinding = makeFinding({ title: 'Dismissed and gone' });
+    const dismissedRecord = makeRecord(dismissedFinding, {
+      dismissedAt: '2026-03-15T00:00:00.000Z',
+      suppressed: false,
+    });
+
+    const result = classifyFindings([currentFinding], {
+      [dismissedRecord.signature]: dismissedRecord,
+    });
+
+    expect(result.summary.resolved).toBe(0);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('skips resolved classification when includeResolved is false', () => {
+    const currentFinding = makeFinding();
+    const goneFinding = makeFinding({ title: 'Not revisited yet' });
+    const goneRecord = makeRecord(goneFinding);
+
+    const result = classifyFindings([currentFinding], { [goneRecord.signature]: goneRecord }, [], {
+      includeResolved: false,
+    });
+
+    expect(result.summary.resolved).toBe(0);
+    expect(result.resolved).toEqual([]);
+  });
 });

--- a/src/report/cross-run-classification.ts
+++ b/src/report/cross-run-classification.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 Alex Rambasek
+
+import type { Finding, FindingCategory, FindingSeverity } from '../types.js';
+import type { HistoricalFindingRecord, HistoricalFlakyPageRecord } from '../memory/types.js';
+import { buildFindingGroupKey } from './collector.js';
+
+export type CrossRunStatus = 'new' | 'recurring' | 'resolved' | 'flaky' | 'suppressed';
+
+export interface CrossRunFindingStatus {
+  signature: string;
+  status: CrossRunStatus;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
+  runCount?: number;
+  dismissalReason?: string;
+}
+
+export interface ResolvedFindingRecord {
+  signature: string;
+  title: string;
+  category: FindingCategory;
+  severity: FindingSeverity;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  runCount: number;
+}
+
+export interface CrossRunSummary {
+  new: number;
+  recurring: number;
+  resolved: number;
+  flaky: number;
+  suppressed: number;
+}
+
+export interface CrossRunClassification {
+  /** Status for findings in the current run, keyed by Finding.id. */
+  byFindingId: Record<string, CrossRunFindingStatus>;
+  /** Prior findings whose signatures are not present in the current run. */
+  resolved: ResolvedFindingRecord[];
+  summary: CrossRunSummary;
+}
+
+function normalizeRoute(urlOrPath?: string): string | undefined {
+  if (!urlOrPath) {
+    return undefined;
+  }
+  try {
+    return new URL(urlOrPath).pathname;
+  } catch {
+    return urlOrPath.startsWith('/') ? urlOrPath : `/${urlOrPath}`;
+  }
+}
+
+function findingIsFlaky(finding: Finding, flakyPages: HistoricalFlakyPageRecord[]): boolean {
+  if (flakyPages.length === 0) {
+    return false;
+  }
+  const candidateRoutes = new Set<string>();
+  for (const occurrence of finding.occurrences) {
+    const route = normalizeRoute(occurrence.route);
+    if (route) candidateRoutes.add(route);
+  }
+  const reproRoute = normalizeRoute(finding.meta?.repro?.route);
+  if (reproRoute) candidateRoutes.add(reproRoute);
+  if (candidateRoutes.size === 0) {
+    return false;
+  }
+  return flakyPages.some((page) => {
+    const pageRoute = normalizeRoute(page.route);
+    return Boolean(pageRoute && candidateRoutes.has(pageRoute));
+  });
+}
+
+export function classifyFindings(
+  findings: Finding[],
+  findingHistory: Record<string, HistoricalFindingRecord>,
+  flakyPages: HistoricalFlakyPageRecord[] = []
+): CrossRunClassification {
+  const byFindingId: Record<string, CrossRunFindingStatus> = {};
+  const currentSignatures = new Set<string>();
+  const summary: CrossRunSummary = {
+    new: 0,
+    recurring: 0,
+    resolved: 0,
+    flaky: 0,
+    suppressed: 0,
+  };
+
+  for (const finding of findings) {
+    const signature = buildFindingGroupKey(finding);
+    currentSignatures.add(signature);
+    const record = findingHistory[signature];
+
+    let status: CrossRunStatus;
+    if (record?.suppressed) {
+      status = 'suppressed';
+    } else if (findingIsFlaky(finding, flakyPages)) {
+      status = 'flaky';
+    } else if (record) {
+      status = 'recurring';
+    } else {
+      status = 'new';
+    }
+
+    summary[status] += 1;
+
+    byFindingId[finding.id] = {
+      signature,
+      status,
+      firstSeenAt: record?.firstSeenAt,
+      lastSeenAt: record?.lastSeenAt,
+      runCount: record?.runCount,
+      dismissalReason: record?.dismissalReason,
+    };
+  }
+
+  const resolved: ResolvedFindingRecord[] = [];
+  for (const record of Object.values(findingHistory)) {
+    if (currentSignatures.has(record.signature)) continue;
+    if (record.suppressed) continue;
+    resolved.push({
+      signature: record.signature,
+      title: record.title,
+      category: record.category,
+      severity: record.severity,
+      firstSeenAt: record.firstSeenAt,
+      lastSeenAt: record.lastSeenAt,
+      runCount: record.runCount,
+    });
+  }
+  summary.resolved = resolved.length;
+
+  return {
+    byFindingId,
+    resolved,
+    summary,
+  };
+}

--- a/src/report/cross-run-classification.ts
+++ b/src/report/cross-run-classification.ts
@@ -53,8 +53,23 @@ function normalizeRoute(urlOrPath?: string): string | undefined {
   }
 }
 
-function findingIsFlaky(finding: Finding, flakyPages: HistoricalFlakyPageRecord[]): boolean {
-  if (flakyPages.length === 0) {
+function isSuppressedRecord(record?: HistoricalFindingRecord): boolean {
+  return Boolean(record?.suppressed || record?.dismissedAt);
+}
+
+function buildFlakyRouteSet(flakyPages: HistoricalFlakyPageRecord[]): Set<string> {
+  const flakyRoutes = new Set<string>();
+  for (const page of flakyPages) {
+    const route = normalizeRoute(page.route);
+    if (route) {
+      flakyRoutes.add(route);
+    }
+  }
+  return flakyRoutes;
+}
+
+function findingIsFlaky(finding: Finding, flakyRoutes: Set<string>): boolean {
+  if (flakyRoutes.size === 0) {
     return false;
   }
   const candidateRoutes = new Set<string>();
@@ -67,19 +82,21 @@ function findingIsFlaky(finding: Finding, flakyPages: HistoricalFlakyPageRecord[
   if (candidateRoutes.size === 0) {
     return false;
   }
-  return flakyPages.some((page) => {
-    const pageRoute = normalizeRoute(page.route);
-    return Boolean(pageRoute && candidateRoutes.has(pageRoute));
-  });
+  return [...candidateRoutes].some((route) => flakyRoutes.has(route));
 }
 
 export function classifyFindings(
   findings: Finding[],
   findingHistory: Record<string, HistoricalFindingRecord>,
-  flakyPages: HistoricalFlakyPageRecord[] = []
+  flakyPages: HistoricalFlakyPageRecord[] = [],
+  options: {
+    includeResolved?: boolean;
+  } = {}
 ): CrossRunClassification {
+  const includeResolved = options.includeResolved ?? true;
   const byFindingId: Record<string, CrossRunFindingStatus> = {};
   const currentSignatures = new Set<string>();
+  const flakyRoutes = buildFlakyRouteSet(flakyPages);
   const summary: CrossRunSummary = {
     new: 0,
     recurring: 0,
@@ -94,9 +111,9 @@ export function classifyFindings(
     const record = findingHistory[signature];
 
     let status: CrossRunStatus;
-    if (record?.suppressed) {
+    if (isSuppressedRecord(record)) {
       status = 'suppressed';
-    } else if (findingIsFlaky(finding, flakyPages)) {
+    } else if (findingIsFlaky(finding, flakyRoutes)) {
       status = 'flaky';
     } else if (record) {
       status = 'recurring';
@@ -117,18 +134,20 @@ export function classifyFindings(
   }
 
   const resolved: ResolvedFindingRecord[] = [];
-  for (const record of Object.values(findingHistory)) {
-    if (currentSignatures.has(record.signature)) continue;
-    if (record.suppressed) continue;
-    resolved.push({
-      signature: record.signature,
-      title: record.title,
-      category: record.category,
-      severity: record.severity,
-      firstSeenAt: record.firstSeenAt,
-      lastSeenAt: record.lastSeenAt,
-      runCount: record.runCount,
-    });
+  if (includeResolved) {
+    for (const record of Object.values(findingHistory)) {
+      if (currentSignatures.has(record.signature)) continue;
+      if (isSuppressedRecord(record)) continue;
+      resolved.push({
+        signature: record.signature,
+        title: record.title,
+        category: record.category,
+        severity: record.severity,
+        firstSeenAt: record.firstSeenAt,
+        lastSeenAt: record.lastSeenAt,
+        runCount: record.runCount,
+      });
+    }
   }
   summary.resolved = resolved.length;
 

--- a/src/report/json.test.ts
+++ b/src/report/json.test.ts
@@ -217,4 +217,61 @@ describe('renderJson', () => {
     expect(JSON.stringify(report)).not.toContain(secret);
     expect(JSON.stringify(report)).not.toContain('[REDACTED]');
   });
+
+  it('omits cross-run signatures from serialized finding and resolved payloads', () => {
+    const report = JSON.parse(
+      renderJson({
+        ...makeResult([
+          {
+            name: 'Area',
+            steps: 1,
+            findings: [
+              {
+                ref: 'fid-1',
+                category: 'Bug',
+                severity: 'Major',
+                title: 'Issue',
+                stepsToReproduce: ['Step'],
+                expected: 'Expected',
+                actual: 'Actual',
+              },
+            ],
+            screenshots: new Map(),
+            evidence: [],
+            coverage: { controlsDiscovered: 0, controlsExercised: 0, events: [] },
+            pageType: 'unknown',
+            status: 'explored',
+          },
+        ]),
+        crossRunClassification: {
+          byFindingId: {
+            'BUG-001': {
+              signature: 'secret-signature',
+              status: 'recurring',
+              firstSeenAt: '2026-01-01T00:00:00.000Z',
+            },
+          },
+          resolved: [
+            {
+              signature: 'resolved-signature',
+              title: 'Resolved title',
+              category: 'Bug',
+              severity: 'Major',
+              firstSeenAt: '2026-01-01T00:00:00.000Z',
+              lastSeenAt: '2026-02-01T00:00:00.000Z',
+              runCount: 2,
+            },
+          ],
+          summary: { new: 0, recurring: 1, resolved: 1, flaky: 0, suppressed: 0 },
+        },
+      })
+    );
+
+    expect(report.findings[0].crossRunStatus).toMatchObject({
+      status: 'recurring',
+      firstSeenAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(report.findings[0].crossRunStatus).not.toHaveProperty('signature');
+    expect(report.crossRunSummary.resolvedFindings[0]).not.toHaveProperty('signature');
+  });
 });

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -68,7 +68,14 @@ export function renderJson(result: RunResult): string {
       impactedAreas: f.impactedAreas,
       occurrences: f.occurrences,
       meta: f.meta ?? null,
+      crossRunStatus: result.crossRunClassification?.byFindingId[f.id] ?? null,
     })),
+    crossRunSummary: result.crossRunClassification
+      ? {
+          ...result.crossRunClassification.summary,
+          resolvedFindings: result.crossRunClassification.resolved,
+        }
+      : null,
     coverage: result.areaResults.map((a) => ({
       name: a.name,
       url: a.url ?? null,

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -68,12 +68,22 @@ export function renderJson(result: RunResult): string {
       impactedAreas: f.impactedAreas,
       occurrences: f.occurrences,
       meta: f.meta ?? null,
-      crossRunStatus: result.crossRunClassification?.byFindingId[f.id] ?? null,
+      crossRunStatus: (() => {
+        const status = result.crossRunClassification?.byFindingId[f.id];
+        if (!status) {
+          return null;
+        }
+        const { signature: _signature, ...sanitizedStatus } = status;
+        return sanitizedStatus;
+      })(),
     })),
     crossRunSummary: result.crossRunClassification
       ? {
           ...result.crossRunClassification.summary,
-          resolvedFindings: result.crossRunClassification.resolved,
+          resolvedFindings: result.crossRunClassification.resolved.map((resolvedFinding) => {
+            const { signature: _signature, ...safeResolvedFinding } = resolvedFinding;
+            return safeResolvedFinding;
+          }),
         }
       : null,
     coverage: result.areaResults.map((a) => ({

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -66,6 +66,25 @@ export function renderMarkdown(result: RunResult): string {
   );
   lines.push('');
 
+  // Changes Since Last Run (cross-run classification)
+  if (result.crossRunClassification) {
+    const { summary, resolved } = result.crossRunClassification;
+    lines.push('## Changes Since Last Run');
+    lines.push(
+      `- ${summary.new} new, ${summary.recurring} recurring, ${summary.resolved} resolved, ${summary.flaky} flaky, ${summary.suppressed} suppressed`
+    );
+    if (resolved.length > 0) {
+      lines.push('');
+      lines.push('**Resolved findings (present in prior runs, absent now):**');
+      for (const entry of resolved) {
+        lines.push(
+          `- ${escapeMarkdownInline(entry.severity)} ${escapeMarkdownInline(entry.category)}: ${escapeMarkdownInline(entry.title)} (last seen ${escapeMarkdownInline(entry.lastSeenAt)}, ${entry.runCount} prior run(s))`
+        );
+      }
+    }
+    lines.push('');
+  }
+
   // Summary
   lines.push('## Summary');
   if (findings.length === 0) {
@@ -97,6 +116,20 @@ export function renderMarkdown(result: RunResult): string {
         `### [${escapeMarkdownInline(f.id)}] ${escapeMarkdownInline(f.severity)}: ${escapeMarkdownInline(f.title)}`
       );
       lines.push(`- **Area:** ${escapeMarkdownInline(f.area)}`);
+      const crossRunStatus = result.crossRunClassification?.byFindingId[f.id];
+      if (crossRunStatus) {
+        const parts = [`status: ${crossRunStatus.status}`];
+        if (crossRunStatus.firstSeenAt) {
+          parts.push(`first seen ${crossRunStatus.firstSeenAt}`);
+        }
+        if (crossRunStatus.runCount !== undefined) {
+          parts.push(`${crossRunStatus.runCount} prior run(s)`);
+        }
+        if (crossRunStatus.dismissalReason) {
+          parts.push(`reason: ${crossRunStatus.dismissalReason}`);
+        }
+        lines.push(`- **Cross-run:** ${escapeMarkdownInline(parts.join(' | '))}`);
+      }
       if (diffScope) {
         const scope = diffScope.get(f.area) ?? 'unchanged';
         lines.push(`- **Diff scope:** ${escapeMarkdownInline(scope)}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 // Copyright (c) 2026 Alex Rambasek
 
+import type { CrossRunClassification } from './report/cross-run-classification.js';
+export type { CrossRunClassification };
+
 export type FindingCategory =
   | 'Bug'
   | 'UX Concern'
@@ -196,6 +199,8 @@ export interface RunResult {
   runMemory?: RunMemoryMeta;
   /** Diff-aware exploration summary, present when diff-aware mode is enabled. */
   diffSummary?: DiffSummary;
+  /** Cross-run classification of findings, present when run memory is enabled. */
+  crossRunClassification?: CrossRunClassification;
 }
 
 export interface RunConfigMeta {


### PR DESCRIPTION
  What changed:
  - New src/report/cross-run-classification.ts — classifyFindings() assigns each current-run finding a status (new |      recurring | resolved | flaky | suppressed) by comparing against MemorySnapshot.findingHistory and flakyPages. Also
  emits a list of prior-run signatures that didn't reappear (resolved) plus a count summary.
  - src/report/cross-run-classification.test.ts — 7 tests covering empty memory, recurring, suppressed (wins over
  flaky), flaky-by-route, resolved, and suppressed-prior-findings-not-counted-as-resolved.
  - src/types.ts — added crossRunClassification? to RunResult (re-exported type).
  - src/report/collector.ts — buildRunResult accepts the classification.
  - src/engine.ts — captures pre-run findingHistory and flakyPages via structuredClone before recordRunFindings mutates
  them, then classifies. Only runs when memory is enabled.
  - src/engine/context.ts, src/engine/reports.ts — plumb classification through.
  - src/report/markdown.ts — adds a "Changes Since Last Run" section with counts and a resolved-findings list; each
  finding gets a **Cross-run:** tag showing status, first-seen, run count, and dismissal reason.
  - src/report/json.ts — each finding carries a crossRunStatus field; top-level crossRunSummary includes counts +
  resolvedFindings.

  Backward compat: If memory is disabled, crossRunClassification is undefined and neither renderer emits the new fields.