### PR TITLE
fix: address PR review feedback for triage commands

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -138,6 +138,44 @@ describe('parseCliArgs', () => {
     const result = parseCliArgs(['setup']);
     expect(result.command).toBe('setup');
   });
+
+  it('parses findings list --suppressed', () => {
+    const result = parseCliArgs(['findings', 'list', '--suppressed']);
+    expect(result).toMatchObject({
+      command: 'findings',
+      triageSubcommand: 'list',
+      triageSuppressedOnly: true,
+    });
+  });
+
+  it('parses findings suppress with reason and positional signature', () => {
+    const result = parseCliArgs(['findings', 'suppress', 'abc123', '--reason', 'known issue']);
+    expect(result).toMatchObject({
+      command: 'findings',
+      triageSubcommand: 'suppress',
+      triagePositional: ['abc123'],
+      triageReason: 'known issue',
+    });
+  });
+
+  it('parses baselines approve --all', () => {
+    const result = parseCliArgs(['baselines', 'approve', '--all']);
+    expect(result).toMatchObject({
+      command: 'baselines',
+      triageSubcommand: 'approve',
+      triageAll: true,
+    });
+  });
+
+  it('parses triage subcommand when global flags appear first', () => {
+    const result = parseCliArgs(['findings', '--config', 'custom.json', 'suppress', 'abc123']);
+    expect(result).toMatchObject({
+      command: 'findings',
+      configPath: 'custom.json',
+      triageSubcommand: 'suppress',
+      triagePositional: ['abc123'],
+    });
+  });
 });
 
 describe('buildHelpText', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -173,12 +173,6 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   if (args.length > 0 && KNOWN_COMMANDS.has(args[0])) {
     command = args[0] as ParsedCliArgs['command'];
     i = 1;
-
-    // For triage commands, the next positional (if any) is the subcommand
-    if (TRIAGE_COMMANDS.has(command) && args.length > 1 && !args[1].startsWith('-')) {
-      triageSubcommand = args[1];
-      i = 2;
-    }
   }
 
   for (; i < args.length; i++) {
@@ -332,7 +326,11 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
 
     // Positional arg for triage commands (signatures, baseline identifiers)
     if (TRIAGE_COMMANDS.has(command)) {
-      triagePositional.push(arg);
+      if (!triageSubcommand) {
+        triageSubcommand = arg;
+      } else {
+        triagePositional.push(arg);
+      }
       continue;
     }
 
@@ -354,11 +352,15 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
     formats,
     initTemplate,
     initOutput,
-    triageSubcommand,
-    triagePositional: triagePositional.length > 0 ? triagePositional : undefined,
-    triageSuppressedOnly,
-    triageAll,
-    triageReason,
+    ...(TRIAGE_COMMANDS.has(command)
+      ? {
+          triageSubcommand,
+          triagePositional: triagePositional.length > 0 ? triagePositional : undefined,
+          triageSuppressedOnly,
+          triageAll,
+          triageReason,
+        }
+      : {}),
   };
 }
 

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -122,6 +122,12 @@ describe('runTriageCommand', () => {
       writeSnapshot(h.memoryDir, [
         makeRecord({ signature: 'a0000000000000', title: 'Kept', suppressed: false }),
         makeRecord({ signature: 'b0000000000000', title: 'Hidden', suppressed: true }),
+        makeRecord({
+          signature: 'c0000000000000',
+          title: 'Hidden via dismissedAt',
+          suppressed: false,
+          dismissedAt: '2026-03-22T00:00:00Z',
+        }),
       ]);
       const code = runTriageCommand(
         { command: 'findings', subcommand: 'list', flags: { suppressed: true }, positional: [] },
@@ -130,6 +136,7 @@ describe('runTriageCommand', () => {
       expect(code).toBe(0);
       const output = h.logs.join('\n');
       expect(output).toContain('Hidden');
+      expect(output).toContain('Hidden via dismissedAt');
       expect(output).not.toContain('Kept');
     });
   });
@@ -223,6 +230,33 @@ describe('runTriageCommand', () => {
       expect(code).toBe(0);
       expect(h.logs.join('\n')).toContain('was not suppressed');
     });
+
+    it('unsuppresses records marked only by dismissedAt', () => {
+      writeSnapshot(h.memoryDir, [
+        makeRecord({
+          signature: 'dismissed123xx',
+          suppressed: false,
+          dismissalReason: 'legacy suppress state',
+          dismissedAt: '2026-03-01T00:00:00Z',
+        }),
+      ]);
+      const code = runTriageCommand(
+        {
+          command: 'findings',
+          subcommand: 'unsuppress',
+          flags: {},
+          positional: ['dismissed123'],
+        },
+        h.deps
+      );
+      expect(code).toBe(0);
+      const snapshot = JSON.parse(
+        readFileSync(join(h.memoryDir, 'memory.json'), 'utf-8')
+      ) as MemorySnapshot;
+      expect(snapshot.findingHistory['dismissed123xx'].suppressed).toBe(false);
+      expect(snapshot.findingHistory['dismissed123xx'].dismissedAt).toBeUndefined();
+      expect(snapshot.findingHistory['dismissed123xx'].dismissalReason).toBeUndefined();
+    });
   });
 
   describe('baselines list / approve', () => {
@@ -288,6 +322,11 @@ describe('runTriageCommand', () => {
       writeSnapshot(h.memoryDir, [
         makeRecord({ signature: 's1xxxxxxxxxxxx' }),
         makeRecord({ signature: 's2xxxxxxxxxxxx', suppressed: true }),
+        makeRecord({
+          signature: 's3xxxxxxxxxxxx',
+          suppressed: false,
+          dismissedAt: '2026-03-01T00:00:00Z',
+        }),
       ]);
       const code = runTriageCommand(
         { command: 'memory', subcommand: 'stats', flags: {}, positional: [] },
@@ -295,8 +334,8 @@ describe('runTriageCommand', () => {
       );
       expect(code).toBe(0);
       const out = h.logs.join('\n');
-      expect(out).toContain('total history entries: 2');
-      expect(out).toContain('suppressed:            1');
+      expect(out).toContain('total history entries: 3');
+      expect(out).toContain('suppressed:            2');
     });
   });
 

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { loadConfig } from '../config.js';
 import { MemoryStore } from '../memory/store.js';
 import type { HistoricalFindingRecord } from '../memory/types.js';
@@ -62,7 +62,9 @@ function listFindings(
   const store = new MemoryStore(paths.memoryDir);
   const snapshot = store.getSnapshot();
   const records = Object.values(snapshot.findingHistory)
-    .filter((record) => (options.suppressedOnly ? (record.suppressed ?? false) : true))
+    .filter((record) =>
+      options.suppressedOnly ? Boolean(record.suppressed || record.dismissedAt) : true
+    )
     .sort((a, b) => b.lastSeenAt.localeCompare(a.lastSeenAt));
 
   if (records.length === 0) {
@@ -87,7 +89,7 @@ function listFindings(
 
   for (const record of records) {
     const shortSig = record.signature.slice(0, 12) + '..';
-    const suppressedMark = record.suppressed ? 'yes' : 'no';
+    const suppressedMark = record.suppressed || record.dismissedAt ? 'yes' : 'no';
     deps.log(
       shortSig.padEnd(14) +
         '  ' +
@@ -145,7 +147,7 @@ function unsuppressFinding(
     deps.error(`No finding matching signature: ${identifier}`);
     return 1;
   }
-  if (!record.suppressed) {
+  if (!record.suppressed && !record.dismissedAt) {
     deps.log(`Finding was not suppressed: ${record.title}`);
     return 0;
   }
@@ -204,11 +206,11 @@ function memoryStats(deps: TriageDependencies, paths: ResolvedTriagePaths): numb
   const store = new MemoryStore(paths.memoryDir);
   const snapshot = store.getSnapshot();
   const findings = Object.values(snapshot.findingHistory);
-  const suppressed = findings.filter((record) => record.suppressed).length;
+  const suppressed = findings.filter((record) => record.suppressed || record.dismissedAt).length;
   const baselines = listBaselineFiles(paths.baselineDir);
 
   deps.log(`Memory store: ${paths.memoryDir}`);
-  if (!existsSync(`${paths.memoryDir}/memory.json`)) {
+  if (!existsSync(join(paths.memoryDir, 'memory.json'))) {
     deps.log('  (no memory.json present — has dramaturge been run with memory enabled?)');
   } else {
     deps.log(`  updated: ${snapshot.updatedAt}`);

--- a/src/coverage/visual-baselines.test.ts
+++ b/src/coverage/visual-baselines.test.ts
@@ -45,6 +45,15 @@ describe('visual-baselines', () => {
     expect(files[0].height).toBeUndefined();
   });
 
+  it('parses hyphenated fingerprint hashes', () => {
+    writeFileSync(join(dir, 'abc-mobile-1280x720.png'), 'fake');
+    const files = listBaselineFiles(dir);
+    expect(files).toHaveLength(1);
+    expect(files[0].fingerprintHash).toBe('abc-mobile');
+    expect(files[0].width).toBe(1280);
+    expect(files[0].height).toBe(720);
+  });
+
   it('removes all baselines when target is "all"', () => {
     writeFileSync(join(dir, 'a-100x200.png'), 'fake');
     writeFileSync(join(dir, 'b-100x200.png'), 'fake');
@@ -77,5 +86,13 @@ describe('visual-baselines', () => {
     const result = approveBaselines(dir, ['abc-100x200.png']);
     expect(result.removed).toHaveLength(1);
     expect(result.notFound).toEqual([]);
+  });
+
+  it('deduplicates matching files across overlapping identifiers', () => {
+    writeFileSync(join(dir, 'abc-100x200.png'), 'fake');
+    const result = approveBaselines(dir, ['abc', 'abc-100x200.png', 'abc']);
+    expect(result.removed).toHaveLength(1);
+    expect(result.notFound).toEqual([]);
+    expect(existsSync(join(dir, 'abc-100x200.png'))).toBe(false);
   });
 });

--- a/src/coverage/visual-baselines.ts
+++ b/src/coverage/visual-baselines.ts
@@ -14,7 +14,7 @@ export interface BaselineFile {
   modifiedAt: string;
 }
 
-const BASELINE_NAME_PATTERN = /^([^-]+)-(\d+)x(\d+)\.png$/;
+const BASELINE_NAME_PATTERN = /^(.+)-(\d+)x(\d+)\.png$/;
 
 export function listBaselineFiles(baselineDir: string): BaselineFile[] {
   if (!existsSync(baselineDir)) {
@@ -71,6 +71,7 @@ export function approveBaselines(
 
   const removed: BaselineFile[] = [];
   const notFound: string[] = [];
+  const removedPaths = new Set<string>();
   for (const identifier of target) {
     const matches = files.filter(
       (file) => file.fingerprintHash === identifier || file.fileName === identifier
@@ -80,8 +81,12 @@ export function approveBaselines(
       continue;
     }
     for (const match of matches) {
+      if (removedPaths.has(match.path)) {
+        continue;
+      }
       unlinkSync(match.path);
       removed.push(match);
+      removedPaths.add(match.path);
     }
   }
   return { removed, notFound };


### PR DESCRIPTION
### Motivation
- Address review feedback that caused triage and baseline workflows to fail for common edge cases and to be brittle across platforms. 
- Ensure triage CLI parsing, suppression semantics, and baseline approval behave consistently with existing memory semantics and responsive baseline naming.

### Description
- Support hyphenated fingerprint hashes in baseline filenames by updating `BASELINE_NAME_PATTERN` and make baseline approval deduplicate matches before calling `unlinkSync` in `src/coverage/visual-baselines.ts`.
- Align triage suppression logic with `MemoryStore` semantics by treating `dismissedAt` as suppressed in `listFindings`, `unsuppressFinding`, and `memoryStats`, and switch to `join(paths.memoryDir, 'memory.json')` for cross-platform checks in `src/commands/triage.ts`.
- Improve CLI triage parsing so the triage subcommand is detected even when global flags appear before it and only include triage-specific fields for triage commands in `src/cli.ts`.
- Add regression tests covering hyphenated baseline parsing, overlapping baseline approvals, `dismissedAt` suppression behavior, unsuppressing legacy records, memory stats counts, and triage argument routing in `src/coverage/visual-baselines.test.ts`, `src/commands/triage.test.ts`, and `src/cli.test.ts`.

### Testing
- Ran targeted Vitest suites with `pnpm run test -- --run src/coverage/visual-baselines.test.ts src/commands/triage.test.ts src/cli.test.ts`, and the tests passed.
- Ran `pnpm run lint` and observed only pre-existing repository warnings unrelated to these changes, with no new errors.
- Ran `pnpm exec prettier --check` for the modified files and fixed style with `prettier --write` so all changed files pass Prettier checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d0526af08327aebfdada779572f1)