### PR TITLE
focus presets

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -119,6 +119,50 @@ describe('parseCliArgs', () => {
     expect(() => parseCliArgs(['run', '--preset', 'invalid'])).toThrow('Invalid preset');
   });
 
+  it('parses new preset names', () => {
+    for (const name of ['security', 'accessibility', 'api-contract', 'visual', 'pre-release']) {
+      const result = parseCliArgs(['run', 'https://example.com', '--preset', name]);
+      expect(result.preset).toBe(name);
+    }
+  });
+
+  it('parses repeated --focus flags', () => {
+    const result = parseCliArgs([
+      'run',
+      'https://example.com',
+      '--focus',
+      'api',
+      '--focus',
+      'adversarial',
+    ]);
+    expect(result.focusModes).toEqual(['api', 'adversarial']);
+  });
+
+  it('parses comma-separated --focus values', () => {
+    const result = parseCliArgs(['run', 'https://example.com', '--focus', 'form,crud']);
+    expect(result.focusModes).toEqual(['form', 'crud']);
+  });
+
+  it('de-duplicates --focus values', () => {
+    const result = parseCliArgs([
+      'run',
+      'https://example.com',
+      '--focus',
+      'api',
+      '--focus',
+      'api,form',
+    ]);
+    expect(result.focusModes).toEqual(['api', 'form']);
+  });
+
+  it('throws for invalid --focus value', () => {
+    expect(() => parseCliArgs(['run', '--focus', 'bogus'])).toThrow('Invalid focus mode');
+  });
+
+  it('throws when --focus has no value', () => {
+    expect(() => parseCliArgs(['run', '--focus'])).toThrow('Missing value for --focus');
+  });
+
   it('parses doctor command', () => {
     const result = parseCliArgs(['doctor']);
     expect(result.command).toBe('doctor');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,14 @@ import { resolveResumeDir } from './config-paths.js';
 import { runEngine, type RunEngineOptions } from './engine.js';
 import { EngineEventEmitter } from './engine/event-stream.js';
 import { loadDotenv } from './env.js';
-import { buildConfigFromArgs, type InlineRunArgs } from './config-inline.js';
+import {
+  buildConfigFromArgs,
+  FOCUS_MODES,
+  PRESET_NAMES,
+  type FocusMode,
+  type InlineRunArgs,
+  type PresetName,
+} from './config-inline.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit, type InitTemplate } from './commands/init.js';
 import { runTriageCommand } from './commands/triage.js';
@@ -37,7 +44,9 @@ export interface ParsedCliArgs {
   /** --provider flag for inline runs */
   provider?: 'anthropic' | 'openai' | 'google' | 'azure' | 'openrouter' | 'github';
   /** --preset flag for inline runs */
-  preset?: 'smoke' | 'thorough';
+  preset?: PresetName;
+  /** --focus flags for inline runs (repeatable, comma-separated values allowed) */
+  focusModes?: FocusMode[];
   /** --format flag — comma-separated list of report formats */
   formats?: Array<'markdown' | 'json' | 'both' | 'junit' | 'sarif'>;
   /** --template flag for init */
@@ -82,7 +91,8 @@ Run options:
   --login              Enable interactive auth (opens browser for sign-in)
   --headless           Run browser in headless mode
   --provider <name>    LLM provider: anthropic, openai, google, azure, openrouter, or github
-  --preset <name>      Use a preset: smoke (quick scan) or thorough (full scan)
+  --preset <name>      Preset: smoke, thorough, security, accessibility, api-contract, visual, pre-release
+  --focus <modes>      Focus modes (repeatable / comma-separated): navigation, form, crud, api, adversarial
   --format <list>      Report formats, comma-separated: markdown, json, junit, sarif, or both (legacy alias) (e.g. markdown,sarif)
   --help, -h           Show this help message
 
@@ -101,6 +111,8 @@ Examples:
   dramaturge run https://my-app.example.com --login    # Run with interactive auth
   dramaturge run --config custom.json                  # Run with config file
   dramaturge run https://app.example.com --preset smoke  # Quick smoke test
+  dramaturge run https://app.example.com --preset security  # Security-focused scan
+  dramaturge run https://app.example.com --focus api --focus adversarial  # Ad-hoc focus mix
   dramaturge setup                                     # Interactive onboarding
   dramaturge init --template minimal                   # Generate minimal config
   dramaturge doctor                                    # Check environment
@@ -144,7 +156,8 @@ const KNOWN_COMMANDS = new Set([
 ]);
 const TRIAGE_COMMANDS = new Set(['findings', 'baselines', 'memory']);
 const VALID_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'azure', 'openrouter', 'github']);
-const VALID_PRESETS = new Set(['smoke', 'thorough']);
+const VALID_PRESETS = new Set<string>(PRESET_NAMES);
+const VALID_FOCUS_MODES = new Set<string>(FOCUS_MODES);
 const VALID_FORMATS = new Set(['markdown', 'json', 'both', 'junit', 'sarif']);
 
 export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
@@ -158,6 +171,7 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   let headless: boolean | undefined;
   let provider: ParsedCliArgs['provider'];
   let preset: ParsedCliArgs['preset'];
+  const focusModes: FocusMode[] = [];
   let formats: ParsedCliArgs['formats'];
   let initTemplate: InitTemplate | undefined;
   let initOutput: string | undefined;
@@ -248,9 +262,33 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
       const value = args[i + 1];
       if (!value) throw new Error('Missing value for --preset');
       if (!VALID_PRESETS.has(value)) {
-        throw new Error(`Invalid preset: ${value}. Must be one of: smoke, thorough`);
+        throw new Error(
+          `Invalid preset: ${value}. Must be one of: ${[...VALID_PRESETS].join(', ')}`
+        );
       }
       preset = value as ParsedCliArgs['preset'];
+      i++;
+      continue;
+    }
+
+    if (arg === '--focus') {
+      const value = args[i + 1];
+      if (!value) throw new Error('Missing value for --focus');
+      const parts = value
+        .split(',')
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+      if (parts.length === 0) throw new Error('Missing value for --focus');
+      for (const part of parts) {
+        if (!VALID_FOCUS_MODES.has(part)) {
+          throw new Error(
+            `Invalid focus mode: ${part}. Must be one of: ${[...VALID_FOCUS_MODES].join(', ')}`
+          );
+        }
+        if (!focusModes.includes(part as FocusMode)) {
+          focusModes.push(part as FocusMode);
+        }
+      }
       i++;
       continue;
     }
@@ -351,6 +389,7 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
     headless,
     provider,
     preset,
+    focusModes: focusModes.length > 0 ? focusModes : undefined,
     formats,
     initTemplate,
     initOutput,
@@ -496,6 +535,7 @@ async function runRunCommand(
       headless: parsedArgs.headless,
       provider: parsedArgs.provider,
       preset: parsedArgs.preset,
+      focusModes: parsedArgs.focusModes,
       formats: parsedArgs.formats,
     };
     config = buildConfigFromArgs(inlineArgs);

--- a/src/config-inline.test.ts
+++ b/src/config-inline.test.ts
@@ -2,7 +2,16 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { buildConfigFromArgs } from './config-inline.js';
+import {
+  buildAccessibilityPreset,
+  buildApiContractPreset,
+  buildConfigFromArgs,
+  buildPreReleasePreset,
+  buildSecurityPreset,
+  buildSmokePreset,
+  buildThoroughPreset,
+  buildVisualPreset,
+} from './config-inline.js';
 
 describe('buildConfigFromArgs', () => {
   beforeEach(() => {
@@ -62,5 +71,145 @@ describe('buildConfigFromArgs', () => {
   it('generates description from hostname when not provided', () => {
     const config = buildConfigFromArgs({ url: 'https://my-app.example.com/path' });
     expect(config.appDescription).toContain('my-app.example.com');
+  });
+
+  it('applies security preset with adversarial+api focus and feature toggles', () => {
+    const config = buildConfigFromArgs({ url: 'https://example.com', preset: 'security' });
+    expect(config.mission?.focusModes).toEqual(['adversarial', 'api']);
+    expect(config.adversarial.enabled).toBe(true);
+    expect(config.adversarial.includeAuthzProbes).toBe(true);
+    expect(config.apiTesting.enabled).toBe(true);
+    expect(config.budget.globalTimeLimitSeconds).toBe(600);
+  });
+
+  it('applies accessibility preset', () => {
+    const config = buildConfigFromArgs({ url: 'https://example.com', preset: 'accessibility' });
+    expect(config.mission?.focusModes).toEqual(['navigation', 'form']);
+    expect(config.responsiveRegression.enabled).toBe(true);
+    expect(config.adversarial.enabled).toBe(false);
+  });
+
+  it('applies api-contract preset', () => {
+    const config = buildConfigFromArgs({ url: 'https://example.com', preset: 'api-contract' });
+    expect(config.mission?.focusModes).toEqual(['api']);
+    expect(config.apiTesting.enabled).toBe(true);
+    expect(config.adversarial.enabled).toBe(false);
+  });
+
+  it('applies visual preset', () => {
+    const config = buildConfigFromArgs({ url: 'https://example.com', preset: 'visual' });
+    expect(config.mission?.focusModes).toEqual(['navigation']);
+    expect(config.visualRegression.enabled).toBe(true);
+    expect(config.responsiveRegression.enabled).toBe(true);
+    expect(config.visionAnalysis.enabled).toBe(true);
+  });
+
+  it('applies pre-release preset covering all dimensions', () => {
+    const config = buildConfigFromArgs({ url: 'https://example.com', preset: 'pre-release' });
+    expect(config.mission?.focusModes).toEqual([
+      'navigation',
+      'form',
+      'crud',
+      'api',
+      'adversarial',
+    ]);
+    expect(config.adversarial.enabled).toBe(true);
+    expect(config.apiTesting.enabled).toBe(true);
+    expect(config.visualRegression.enabled).toBe(true);
+    expect(config.responsiveRegression.enabled).toBe(true);
+    expect(config.webVitals.enabled).toBe(true);
+    expect(config.visionAnalysis.enabled).toBe(true);
+    expect(config.budget.globalTimeLimitSeconds).toBe(1800);
+  });
+
+  it('--focus overrides preset focus modes', () => {
+    const config = buildConfigFromArgs({
+      url: 'https://example.com',
+      preset: 'smoke',
+      focusModes: ['api', 'adversarial'],
+    });
+    expect(config.mission?.focusModes).toEqual(['api', 'adversarial']);
+    expect(config.apiTesting.enabled).toBe(true);
+    expect(config.adversarial.enabled).toBe(true);
+  });
+
+  it('--focus alone sets focus modes without a preset', () => {
+    const config = buildConfigFromArgs({
+      url: 'https://example.com',
+      focusModes: ['form'],
+    });
+    expect(config.mission?.focusModes).toEqual(['form']);
+    expect(config.apiTesting.enabled).toBe(false);
+    expect(config.adversarial.enabled).toBe(false);
+  });
+
+  it('--focus de-duplicates repeated values', () => {
+    const config = buildConfigFromArgs({
+      url: 'https://example.com',
+      focusModes: ['api', 'api', 'form'],
+    });
+    expect(config.mission?.focusModes).toEqual(['api', 'form']);
+  });
+
+  it('preserves security preset feature toggles when focus narrows to api', () => {
+    const config = buildConfigFromArgs({
+      url: 'https://example.com',
+      preset: 'security',
+      focusModes: ['api'],
+    });
+    expect(config.mission?.focusModes).toEqual(['api']);
+    expect(config.apiTesting.enabled).toBe(true);
+    expect(config.adversarial.enabled).toBe(true);
+  });
+});
+
+describe('preset builders', () => {
+  it('smoke preset is unchanged', () => {
+    const preset = buildSmokePreset();
+    expect(preset.budget?.globalTimeLimitSeconds).toBe(180);
+    expect(preset.exploration?.maxAreasToExplore).toBe(3);
+    expect(preset.mission).toBeUndefined();
+  });
+
+  it('thorough preset is unchanged', () => {
+    const preset = buildThoroughPreset();
+    expect(preset.budget?.globalTimeLimitSeconds).toBe(1800);
+    expect(preset.mission).toBeUndefined();
+  });
+
+  it('security preset sets adversarial+api focus', () => {
+    const preset = buildSecurityPreset();
+    expect(preset.mission?.focusModes).toEqual(['adversarial', 'api']);
+    expect(preset.adversarial?.enabled).toBe(true);
+    expect(preset.apiTesting?.enabled).toBe(true);
+  });
+
+  it('accessibility preset sets navigation+form focus and responsive checks', () => {
+    const preset = buildAccessibilityPreset();
+    expect(preset.mission?.focusModes).toEqual(['navigation', 'form']);
+    expect(preset.responsiveRegression?.enabled).toBe(true);
+  });
+
+  it('api-contract preset focuses on api only', () => {
+    const preset = buildApiContractPreset();
+    expect(preset.mission?.focusModes).toEqual(['api']);
+    expect(preset.apiTesting?.enabled).toBe(true);
+  });
+
+  it('visual preset enables visual/responsive/vision checks', () => {
+    const preset = buildVisualPreset();
+    expect(preset.visualRegression?.enabled).toBe(true);
+    expect(preset.responsiveRegression?.enabled).toBe(true);
+    expect(preset.visionAnalysis?.enabled).toBe(true);
+  });
+
+  it('pre-release preset enables all coverage dimensions', () => {
+    const preset = buildPreReleasePreset();
+    expect(preset.adversarial?.enabled).toBe(true);
+    expect(preset.apiTesting?.enabled).toBe(true);
+    expect(preset.visualRegression?.enabled).toBe(true);
+    expect(preset.responsiveRegression?.enabled).toBe(true);
+    expect(preset.webVitals?.enabled).toBe(true);
+    expect(preset.visionAnalysis?.enabled).toBe(true);
   });
 });

--- a/src/config-inline.ts
+++ b/src/config-inline.ts
@@ -7,12 +7,35 @@ import { normalizeConfigPaths, type ConfigWithMeta } from './config-paths.js';
 import { detectProviderFromEnv } from './llm/index.js';
 import type { ProviderId } from './llm/index.js';
 
+export type FocusMode = 'navigation' | 'form' | 'crud' | 'api' | 'adversarial';
+
+export const PRESET_NAMES = [
+  'smoke',
+  'thorough',
+  'security',
+  'accessibility',
+  'api-contract',
+  'visual',
+  'pre-release',
+] as const;
+
+export type PresetName = (typeof PRESET_NAMES)[number];
+
+export const FOCUS_MODES: readonly FocusMode[] = [
+  'navigation',
+  'form',
+  'crud',
+  'api',
+  'adversarial',
+];
+
 export interface InlineRunArgs {
   url: string;
   login?: boolean;
   headless?: boolean;
   provider?: ProviderId;
-  preset?: 'smoke' | 'thorough';
+  preset?: PresetName;
+  focusModes?: FocusMode[];
   description?: string;
   formats?: Array<'markdown' | 'json' | 'both' | 'junit' | 'sarif'>;
 }
@@ -44,40 +67,210 @@ const PROVIDER_DEFAULTS: Record<ProviderId, { planner: string; worker: string }>
   },
 };
 
-function buildSmokePreset(): Partial<DramaturgeConfig> {
+const SMOKE_BUDGET = {
+  globalTimeLimitSeconds: 180,
+  maxStepsPerTask: 20,
+  maxFrontierSize: 30,
+  maxStateNodes: 10,
+  stagnationThreshold: 5,
+  costLimitUsd: 0,
+};
+
+const SMOKE_EXPLORATION = {
+  maxAreasToExplore: 3,
+  stepsPerArea: 20,
+  totalTimeout: 180,
+};
+
+const MEDIUM_BUDGET = {
+  globalTimeLimitSeconds: 600,
+  maxStepsPerTask: 40,
+  maxFrontierSize: 100,
+  maxStateNodes: 30,
+  stagnationThreshold: 6,
+  costLimitUsd: 0,
+};
+
+const MEDIUM_EXPLORATION = {
+  maxAreasToExplore: 8,
+  stepsPerArea: 40,
+  totalTimeout: 600,
+};
+
+const THOROUGH_BUDGET = {
+  globalTimeLimitSeconds: 1800,
+  maxStepsPerTask: 60,
+  maxFrontierSize: 300,
+  maxStateNodes: 80,
+  stagnationThreshold: 8,
+  costLimitUsd: 0,
+};
+
+const THOROUGH_EXPLORATION = {
+  maxAreasToExplore: 20,
+  stepsPerArea: 60,
+  totalTimeout: 1800,
+};
+
+export function buildSmokePreset(): Partial<DramaturgeConfig> {
   return {
-    budget: {
-      globalTimeLimitSeconds: 180,
-      maxStepsPerTask: 20,
-      maxFrontierSize: 30,
-      maxStateNodes: 10,
-      stagnationThreshold: 5,
-      costLimitUsd: 0,
+    budget: { ...SMOKE_BUDGET },
+    exploration: { ...SMOKE_EXPLORATION },
+  };
+}
+
+export function buildThoroughPreset(): Partial<DramaturgeConfig> {
+  return {
+    budget: { ...THOROUGH_BUDGET },
+    exploration: { ...THOROUGH_EXPLORATION },
+  };
+}
+
+export function buildSecurityPreset(): Partial<DramaturgeConfig> {
+  return {
+    budget: { ...MEDIUM_BUDGET },
+    exploration: { ...MEDIUM_EXPLORATION },
+    mission: {
+      destructiveActionsAllowed: false,
+      focusModes: ['adversarial', 'api'],
     },
-    exploration: {
-      maxAreasToExplore: 3,
-      stepsPerArea: 20,
-      totalTimeout: 180,
+    adversarial: {
+      enabled: true,
+      maxSequencesPerNode: 3,
+      safeMode: true,
+      includeAuthzProbes: true,
+      includeConcurrencyProbes: false,
+    },
+    apiTesting: {
+      enabled: true,
+      maxEndpointsPerNode: 4,
+      maxProbeCasesPerEndpoint: 6,
+      unauthenticatedProbes: true,
+      allowMutatingProbes: false,
     },
   };
 }
 
-function buildThoroughPreset(): Partial<DramaturgeConfig> {
+export function buildAccessibilityPreset(): Partial<DramaturgeConfig> {
   return {
-    budget: {
-      globalTimeLimitSeconds: 1800,
-      maxStepsPerTask: 60,
-      maxFrontierSize: 300,
-      maxStateNodes: 80,
-      stagnationThreshold: 8,
-      costLimitUsd: 0,
+    budget: { ...MEDIUM_BUDGET },
+    exploration: { ...MEDIUM_EXPLORATION },
+    mission: {
+      destructiveActionsAllowed: false,
+      focusModes: ['navigation', 'form'],
     },
-    exploration: {
-      maxAreasToExplore: 20,
-      stepsPerArea: 60,
-      totalTimeout: 1800,
+    responsiveRegression: {
+      enabled: true,
     },
   };
+}
+
+export function buildApiContractPreset(): Partial<DramaturgeConfig> {
+  return {
+    budget: { ...MEDIUM_BUDGET },
+    exploration: { ...MEDIUM_EXPLORATION },
+    mission: {
+      destructiveActionsAllowed: false,
+      focusModes: ['api'],
+    },
+    apiTesting: {
+      enabled: true,
+      maxEndpointsPerNode: 6,
+      maxProbeCasesPerEndpoint: 8,
+      unauthenticatedProbes: true,
+      allowMutatingProbes: false,
+    },
+  };
+}
+
+export function buildVisualPreset(): Partial<DramaturgeConfig> {
+  return {
+    budget: { ...MEDIUM_BUDGET },
+    exploration: { ...MEDIUM_EXPLORATION },
+    mission: {
+      destructiveActionsAllowed: false,
+      focusModes: ['navigation'],
+    },
+    visualRegression: {
+      enabled: true,
+      baselineDir: './.dramaturge/visual-baselines',
+      diffPixelRatioThreshold: 0.01,
+      includeAA: false,
+      fullPage: true,
+      maskSelectors: [],
+    },
+    responsiveRegression: {
+      enabled: true,
+    },
+    visionAnalysis: {
+      enabled: true,
+      model: 'anthropic/claude-sonnet-4-20250514',
+      fullPage: false,
+      maxResponseTokens: 1024,
+      requestTimeoutMs: 30_000,
+    },
+  };
+}
+
+export function buildPreReleasePreset(): Partial<DramaturgeConfig> {
+  return {
+    budget: { ...THOROUGH_BUDGET },
+    exploration: { ...THOROUGH_EXPLORATION },
+    mission: {
+      destructiveActionsAllowed: false,
+      focusModes: ['navigation', 'form', 'crud', 'api', 'adversarial'],
+    },
+    adversarial: {
+      enabled: true,
+      maxSequencesPerNode: 3,
+      safeMode: true,
+      includeAuthzProbes: true,
+      includeConcurrencyProbes: false,
+    },
+    apiTesting: {
+      enabled: true,
+      maxEndpointsPerNode: 4,
+      maxProbeCasesPerEndpoint: 6,
+      unauthenticatedProbes: true,
+      allowMutatingProbes: false,
+    },
+    visualRegression: {
+      enabled: true,
+      baselineDir: './.dramaturge/visual-baselines',
+      diffPixelRatioThreshold: 0.01,
+      includeAA: false,
+      fullPage: true,
+      maskSelectors: [],
+    },
+    responsiveRegression: {
+      enabled: true,
+    },
+    webVitals: {
+      enabled: true,
+      thresholds: { lcpMs: 2500, cls: 0.1, inpMs: 200 },
+    },
+    visionAnalysis: {
+      enabled: true,
+      model: 'anthropic/claude-sonnet-4-20250514',
+      fullPage: false,
+      maxResponseTokens: 1024,
+      requestTimeoutMs: 30_000,
+    },
+  };
+}
+
+const PRESET_BUILDERS: Record<PresetName, () => Partial<DramaturgeConfig>> = {
+  smoke: buildSmokePreset,
+  thorough: buildThoroughPreset,
+  security: buildSecurityPreset,
+  accessibility: buildAccessibilityPreset,
+  'api-contract': buildApiContractPreset,
+  visual: buildVisualPreset,
+  'pre-release': buildPreReleasePreset,
+};
+
+export function buildPreset(name: PresetName): Partial<DramaturgeConfig> {
+  return PRESET_BUILDERS[name]();
 }
 
 /**
@@ -120,10 +313,31 @@ export function buildConfigFromArgs(args: InlineRunArgs): ConfigWithMeta<Dramatu
     },
   };
 
-  if (args.preset === 'smoke') {
-    Object.assign(raw, buildSmokePreset());
-  } else if (args.preset === 'thorough') {
-    Object.assign(raw, buildThoroughPreset());
+  if (args.preset) {
+    Object.assign(raw, buildPreset(args.preset));
+  }
+
+  if (args.focusModes && args.focusModes.length > 0) {
+    const uniqueFocus = [...new Set(args.focusModes)];
+    const existingMission = raw.mission as Partial<DramaturgeConfig['mission']> | undefined;
+    raw.mission = {
+      ...(existingMission ?? { destructiveActionsAllowed: false }),
+      focusModes: uniqueFocus,
+    } satisfies Partial<DramaturgeConfig['mission']>;
+    if (uniqueFocus.includes('adversarial')) {
+      const existing = raw.adversarial as Partial<DramaturgeConfig['adversarial']> | undefined;
+      raw.adversarial = {
+        ...existing,
+        enabled: true,
+      } satisfies Partial<DramaturgeConfig['adversarial']>;
+    }
+    if (uniqueFocus.includes('api')) {
+      const existing = raw.apiTesting as Partial<DramaturgeConfig['apiTesting']> | undefined;
+      raw.apiTesting = {
+        ...existing,
+        enabled: true,
+      } satisfies Partial<DramaturgeConfig['apiTesting']>;
+    }
   }
 
   const validated = ConfigSchema.parse(raw);


### PR DESCRIPTION
  Changes:
  - src/config-inline.ts — added 5 new preset builders (security, accessibility, api-contract, visual, pre-release),      exported FOCUS_MODES/PRESET_NAMES/FocusMode/PresetName, added focus-mode override logic (focus flags override preset
  focus modes and auto-enable matching feature toggles).
  - src/cli.ts — added --focus flag (repeatable + comma-separated, de-duplicated), expanded --preset validation, updated
   help text and examples.
  - src/config-inline.test.ts — added 13 tests covering each preset + focus override cases.
  - src/cli.test.ts — added 6 tests for --focus parsing and new preset names.

  Reviewer pass + fixes applied:
  - HIGH: Refactored unsafe as Record<string, unknown> casts to properly-typed Partial<DramaturgeConfig['...']> with
  satisfies assertions.
  - MINOR: Removed redundant ?? undefined.