### PR TITLE
Repo-aware config bootstrap via setup --scan

### DIFF
--- a/src/adaptation/repo-scan.ts
+++ b/src/adaptation/repo-scan.ts
@@ -139,7 +139,7 @@ function loadHintsOverride(root: string, hintsFile?: string): RepoHintsOverride 
   return RepoHintsOverrideSchema.parse(parseJsoncObject(raw));
 }
 
-function detectFramework(root: string): RepoFramework {
+export function detectFramework(root: string): RepoFramework {
   // Check framework-specific markers first (no full file walk needed)
   if (canScanNuxtRepo(root)) return 'nuxt';
   if (canScanSvelteKitRepo(root)) return 'sveltekit';

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -23,6 +23,8 @@ describe('parseCliArgs', () => {
         preset: undefined,
         initTemplate: undefined,
         initOutput: undefined,
+        repoPath: undefined,
+        noScan: undefined,
       }
     );
   });
@@ -42,6 +44,8 @@ describe('parseCliArgs', () => {
       preset: undefined,
       initTemplate: undefined,
       initOutput: undefined,
+      repoPath: undefined,
+      noScan: undefined,
     });
   });
 
@@ -137,6 +141,34 @@ describe('parseCliArgs', () => {
   it('parses setup command', () => {
     const result = parseCliArgs(['setup']);
     expect(result.command).toBe('setup');
+  });
+
+  it('parses setup --repo flag', () => {
+    const result = parseCliArgs(['setup', '--repo', './app']);
+    expect(result.command).toBe('setup');
+    expect(result.repoPath).toBe('./app');
+  });
+
+  it('parses setup --no-scan flag', () => {
+    const result = parseCliArgs(['setup', '--no-scan']);
+    expect(result.command).toBe('setup');
+    expect(result.noScan).toBe(true);
+  });
+
+  it('throws when --repo has no value', () => {
+    expect(() => parseCliArgs(['setup', '--repo'])).toThrow('Missing value for --repo');
+  });
+
+  it('throws when --repo is followed by another flag (missing path)', () => {
+    expect(() => parseCliArgs(['setup', '--repo', '--no-scan'])).toThrow(
+      'Missing value for --repo'
+    );
+  });
+
+  it('throws when --repo and --no-scan are both passed', () => {
+    expect(() => parseCliArgs(['setup', '--repo', '.', '--no-scan'])).toThrow(
+      '--no-scan and --repo cannot be used together'
+    );
   });
 
   it('parses findings list --suppressed', () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,6 +44,10 @@ export interface ParsedCliArgs {
   initTemplate?: InitTemplate;
   /** --output flag for init */
   initOutput?: string;
+  /** --repo flag for setup: path to scan for repo-aware bootstrap */
+  repoPath?: string;
+  /** --no-scan flag for setup: disables repo scan entirely */
+  noScan?: true;
   /** Subcommand after findings/baselines/memory (e.g. "list", "suppress") */
   triageSubcommand?: string;
   /** Positional args for triage subcommands */
@@ -90,6 +94,10 @@ Init options:
   --template <name>    Template to use: minimal (default) or full
   --url <url>          Pre-fill target URL in generated config
   --output <path>      Output path for generated config file
+
+Setup options:
+  --repo <path>        Scan this repo path for routes, endpoints, and auth hints
+  --no-scan            Skip repo scanning (default is auto-scan when in a git repo)
 
 Triage options:
   --suppressed         findings list: only show suppressed findings
@@ -161,6 +169,8 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   let formats: ParsedCliArgs['formats'];
   let initTemplate: InitTemplate | undefined;
   let initOutput: string | undefined;
+  let repoPath: string | undefined;
+  let noScan: true | undefined;
   let triageSubcommand: string | undefined;
   const triagePositional: string[] = [];
   let triageSuppressedOnly: boolean | undefined;
@@ -288,6 +298,19 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
       continue;
     }
 
+    if (arg === '--repo') {
+      const value = args[i + 1];
+      if (!value || value.startsWith('-')) throw new Error('Missing value for --repo');
+      repoPath = value;
+      i++;
+      continue;
+    }
+
+    if (arg === '--no-scan') {
+      noScan = true;
+      continue;
+    }
+
     if (arg === '--output') {
       const value = args[i + 1];
       if (!value) throw new Error('Missing value for --output');
@@ -337,6 +360,10 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (noScan && repoPath) {
+    throw new Error('--no-scan and --repo cannot be used together');
+  }
+
   return {
     command,
     configPath,
@@ -352,6 +379,8 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
     formats,
     initTemplate,
     initOutput,
+    repoPath,
+    noScan,
     ...(TRIAGE_COMMANDS.has(command)
       ? {
           triageSubcommand,
@@ -399,7 +428,7 @@ export async function runCli(
         );
 
       case 'setup':
-        return await runSetupCommand(dependencies);
+        return await runSetupCommand(dependencies, parsedArgs);
 
       case 'run':
         return await runRunCommand(parsedArgs, dependencies);
@@ -434,7 +463,10 @@ export async function runCli(
   }
 }
 
-async function runSetupCommand(dependencies: CliDependencies): Promise<number> {
+async function runSetupCommand(
+  dependencies: CliDependencies,
+  parsedArgs: ParsedCliArgs
+): Promise<number> {
   const { runSetup } = await import('./commands/setup.js');
   const readline = await import('node:readline');
 
@@ -471,14 +503,19 @@ async function runSetupCommand(dependencies: CliDependencies): Promise<number> {
     });
 
   try {
-    return await runSetup({
-      log: dependencies.log,
-      error: dependencies.error,
-      cwd: process.cwd(),
-      prompt,
-      confirm,
-      select,
-    });
+    return await runSetup(
+      {
+        log: dependencies.log,
+        error: dependencies.error,
+        cwd: process.cwd(),
+        prompt,
+        confirm,
+        select,
+      },
+      {
+        repoPath: parsedArgs.noScan ? false : parsedArgs.repoPath,
+      }
+    );
   } finally {
     rl.close();
   }

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-3.0-only
+// Copyright (c) 2026 Alex Rambasek
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { runSetup } from './setup.js';
+import type { SetupDependencies, RepoScanResult } from './setup.js';
+import type { RepoHints } from '../adaptation/types.js';
+
+function makeHints(overrides: Partial<RepoHints> = {}): RepoHints {
+  return {
+    routes: [],
+    routeFamilies: [],
+    stableSelectors: [],
+    apiEndpoints: [],
+    authHints: { loginRoutes: [], callbackRoutes: [] },
+    expectedHttpNoise: [],
+    ...overrides,
+  };
+}
+
+interface Harness {
+  deps: SetupDependencies;
+  messages: string[];
+  errors: string[];
+  promptQueue: string[];
+  confirmQueue: boolean[];
+  selectQueue: string[];
+  promptCalls: string[];
+  confirmCalls: Array<{ question: string; defaultValue?: boolean }>;
+}
+
+function makeHarness(
+  cwd: string,
+  queues: {
+    prompts?: string[];
+    confirms?: boolean[];
+    selects?: string[];
+    scan?: () => RepoScanResult;
+  } = {}
+): Harness {
+  const messages: string[] = [];
+  const errors: string[] = [];
+  const promptQueue = queues.prompts ?? [];
+  const confirmQueue = queues.confirms ?? [];
+  const selectQueue = queues.selects ?? [];
+  const promptCalls: string[] = [];
+  const confirmCalls: Array<{ question: string; defaultValue?: boolean }> = [];
+
+  const deps: SetupDependencies = {
+    log: (msg) => messages.push(msg),
+    error: (msg) => errors.push(msg),
+    cwd,
+    prompt: async (question) => {
+      promptCalls.push(question);
+      return promptQueue.shift() ?? '';
+    },
+    confirm: async (question, defaultValue) => {
+      confirmCalls.push({ question, defaultValue });
+      const next = confirmQueue.shift();
+      return next ?? defaultValue ?? false;
+    },
+    select: async (_question, options) => {
+      return selectQueue.shift() ?? options[0];
+    },
+    scanRepo: queues.scan,
+  };
+  return {
+    deps,
+    messages,
+    errors,
+    promptQueue,
+    confirmQueue,
+    selectQueue,
+    promptCalls,
+    confirmCalls,
+  };
+}
+
+describe('runSetup', () => {
+  let testDir: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'dramaturge-setup-'));
+    // Prevent the wizard from prompting for an API key.
+    savedEnv = {
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+    };
+    process.env.ANTHROPIC_API_KEY = 'test-key';
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('skips repo scan when --no-scan equivalent is passed', async () => {
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'Test app'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+      scan: () => {
+        throw new Error('scanner should not run when repoPath is false');
+      },
+    });
+
+    const code = await runSetup(h.deps, { repoPath: false });
+    expect(code).toBe(0);
+
+    const configPath = resolve(testDir, 'dramaturge.config.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(config.targetUrl).toBe('https://example.com');
+    expect(config.repoContext).toBeUndefined();
+    expect(config.apiTesting).toBeUndefined();
+  });
+
+  it('includes repoContext and suggested toggles when scan detects hints', async () => {
+    const scan: RepoScanResult = {
+      root: testDir,
+      framework: 'nextjs',
+      hints: makeHints({
+        routes: ['/', '/dashboard', '/login'],
+        apiEndpoints: [{ route: '/api/items', methods: ['GET', 'POST'], statuses: [200, 201] }],
+        authHints: { loginRoutes: ['/login'], callbackRoutes: [] },
+      }),
+    };
+
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'Next.js app'],
+      confirms: [
+        /* use detected hints */ true,
+        /* requiresLogin (default true because login route detected) */ true,
+        /* headless */ false,
+        /* enable API testing */ true,
+        /* enable adversarial */ false,
+        /* saveConfig */ true,
+      ],
+      selects: ['Anthropic'],
+      scan: () => scan,
+    });
+
+    const code = await runSetup(h.deps, { repoPath: testDir });
+    expect(code).toBe(0);
+
+    const configPath = resolve(testDir, 'dramaturge.config.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(config.repoContext).toEqual({ root: '.', framework: 'nextjs' });
+    expect(config.apiTesting).toEqual({ enabled: true });
+    expect(config.adversarial).toBeUndefined();
+    expect(config.auth.type).toBe('interactive');
+    expect(config.auth.loginUrl).toBe('https://example.com/login');
+  });
+
+  it('auto-detects a git repo in cwd and scans it', async () => {
+    // Make testDir look like a git repo
+    mkdirSync(resolve(testDir, '.git'));
+
+    let scanned = false;
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+      scan: () => {
+        scanned = true;
+        return { root: testDir, framework: 'generic', hints: makeHints() };
+      },
+    });
+
+    const code = await runSetup(h.deps);
+    expect(code).toBe(0);
+    expect(scanned).toBe(true);
+  });
+
+  it('does not auto-scan when cwd is not a git repo', async () => {
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+      scan: () => {
+        throw new Error('scanner should not run without .git or --repo');
+      },
+    });
+
+    const code = await runSetup(h.deps);
+    expect(code).toBe(0);
+  });
+
+  it('rejects invalid target URLs', async () => {
+    const h = makeHarness(testDir, {
+      prompts: ['not a url'],
+    });
+    const code = await runSetup(h.deps, { repoPath: false });
+    expect(code).toBe(1);
+    expect(h.errors.some((e) => e.includes('Invalid URL'))).toBe(true);
+  });
+
+  it('reports an error when explicit --repo path does not exist', async () => {
+    const missing = resolve(testDir, 'does-not-exist');
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+    });
+
+    const code = await runSetup(h.deps, { repoPath: missing });
+    expect(code).toBe(0);
+    expect(h.errors.some((e) => e.includes('Repo path not found'))).toBe(true);
+    // Config is still written but without repoContext
+    const config = JSON.parse(readFileSync(resolve(testDir, 'dramaturge.config.json'), 'utf8'));
+    expect(config.repoContext).toBeUndefined();
+  });
+
+  it('skips repoContext when hints are empty even with successful scan', async () => {
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+      scan: () => ({ root: testDir, framework: 'generic', hints: makeHints() }),
+    });
+
+    const code = await runSetup(h.deps, { repoPath: testDir });
+    expect(code).toBe(0);
+    const config = JSON.parse(readFileSync(resolve(testDir, 'dramaturge.config.json'), 'utf8'));
+    expect(config.repoContext).toBeUndefined();
+  });
+
+  it('records repoContext when framework is detected but no hints were extracted', async () => {
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+      scan: () => ({ root: testDir, framework: 'nextjs', hints: makeHints() }),
+    });
+
+    const code = await runSetup(h.deps, { repoPath: testDir });
+    expect(code).toBe(0);
+    const config = JSON.parse(readFileSync(resolve(testDir, 'dramaturge.config.json'), 'utf8'));
+    expect(config.repoContext).toEqual({ root: '.', framework: 'nextjs' });
+  });
+
+  it('auto-detects git repo from a subdirectory by walking upward', async () => {
+    mkdirSync(resolve(testDir, '.git'));
+    const subDir = resolve(testDir, 'packages', 'web');
+    mkdirSync(subDir, { recursive: true });
+
+    let scannedRoot: string | undefined;
+    const subHarness = makeHarness(subDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [/* requiresLogin */ false, /* headless */ false, /* saveConfig */ true],
+      selects: ['Anthropic'],
+      scan: (root) => {
+        scannedRoot = root;
+        return { root, framework: 'generic', hints: makeHints() };
+      },
+    });
+
+    const code = await runSetup(subHarness.deps);
+    expect(code).toBe(0);
+    expect(scannedRoot).toBe(testDir);
+  });
+
+  it('does not overwrite existing config when user declines', async () => {
+    const configPath = resolve(testDir, 'dramaturge.config.json');
+    writeFileSync(configPath, '{"existing":true}\n');
+
+    const h = makeHarness(testDir, {
+      prompts: ['https://example.com', 'App'],
+      confirms: [
+        /* requiresLogin */ false,
+        /* headless */ false,
+        /* saveConfig */ true,
+        /* overwrite */ false,
+      ],
+      selects: ['Anthropic'],
+    });
+
+    const code = await runSetup(h.deps, { repoPath: false });
+    expect(code).toBe(0);
+    expect(readFileSync(configPath, 'utf8')).toBe('{"existing":true}\n');
+  });
+});

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -2,7 +2,9 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
+import { resolve, relative, dirname, isAbsolute } from 'node:path';
+import { detectFramework, scanRepository } from '../adaptation/repo-scan.js';
+import type { RepoFramework, RepoHints } from '../adaptation/types.js';
 
 export interface SetupAnswers {
   targetUrl: string;
@@ -14,6 +16,21 @@ export interface SetupAnswers {
   saveConfig: boolean;
 }
 
+export interface SetupArgs {
+  /**
+   * Path to scan for repo-aware bootstrap. Relative paths resolve against cwd.
+   * When omitted, runSetup auto-detects by looking for `.git` in cwd.
+   * Pass `false` to disable scanning entirely.
+   */
+  repoPath?: string | false;
+}
+
+export interface RepoScanResult {
+  root: string;
+  framework: RepoFramework;
+  hints: RepoHints;
+}
+
 export interface SetupDependencies {
   log: (message: string) => void;
   error: (message: string) => void;
@@ -21,6 +38,8 @@ export interface SetupDependencies {
   prompt: (question: string) => Promise<string>;
   confirm: (question: string, defaultValue?: boolean) => Promise<boolean>;
   select: (question: string, options: string[]) => Promise<string>;
+  /** Scanner override for tests. Defaults to calling scanRepository(). */
+  scanRepo?: (root: string) => RepoScanResult;
 }
 
 const PROVIDER_ENV_KEYS: Record<string, string> = {
@@ -59,13 +78,65 @@ const PROVIDER_MODELS: Record<string, { planner: string; worker: string }> = {
   },
 };
 
+const FRAMEWORK_LABELS: Record<RepoFramework, string> = {
+  auto: 'auto-detect',
+  nextjs: 'Next.js',
+  nuxt: 'Nuxt',
+  sveltekit: 'SvelteKit',
+  remix: 'Remix',
+  astro: 'Astro',
+  'react-router': 'React Router',
+  express: 'Express',
+  'vue-router': 'Vue Router',
+  django: 'Django',
+  fastapi: 'FastAPI',
+  rails: 'Rails',
+  'tanstack-router': 'TanStack Router',
+  generic: 'generic',
+};
+
+function defaultScan(root: string): RepoScanResult {
+  const framework = detectFramework(root);
+  const hints = scanRepository({ root, framework });
+  return { root, framework, hints };
+}
+
+/**
+ * Walk upward from `dir` looking for a `.git` marker. Returns the directory that
+ * contains `.git`, or null if none is found before reaching the filesystem root.
+ */
+function findGitRoot(dir: string): string | null {
+  let current = resolve(dir);
+  while (true) {
+    if (existsSync(resolve(current, '.git'))) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function hintsAreMeaningful(hints: RepoHints): boolean {
+  return (
+    hints.routes.length > 0 ||
+    hints.routeFamilies.length > 0 ||
+    hints.stableSelectors.length > 0 ||
+    hints.apiEndpoints.length > 0 ||
+    hints.authHints.loginRoutes.length > 0 ||
+    hints.authHints.callbackRoutes.length > 0 ||
+    hints.expectedHttpNoise.length > 0
+  );
+}
+
 /**
  * Run the interactive setup wizard.
  * Collects user answers and writes config + optional .env.
  */
-export async function runSetup(deps: SetupDependencies): Promise<number> {
+export async function runSetup(deps: SetupDependencies, args: SetupArgs = {}): Promise<number> {
   deps.log('Welcome to Dramaturge Setup!\n');
   deps.log('This wizard will create a config file and get you ready to run.\n');
+
+  // 0. Repo scan (optional, auto-detects when inside a git repo)
+  const scan = await maybeRunRepoScan(deps, args);
 
   // 1. Target URL
   const targetUrl = await deps.prompt('What URL should I test?');
@@ -87,52 +158,57 @@ export async function runSetup(deps: SetupDependencies): Promise<number> {
   );
 
   // 3. Auth
-  const requiresLogin = await deps.confirm('Does the app require login?', false);
-
-  // 4. Provider
-  const provider = await deps.select('Which LLM provider do you want to use?', [
-    'Anthropic',
-    'OpenAI',
-    'Google',
-    'Azure AI Foundry',
-    'OpenRouter',
-    'GitHub Models',
-  ]);
-  const providerKeyMap: Record<string, string> = {
-    anthropic: 'anthropic',
-    openai: 'openai',
-    google: 'google',
-    'azure ai foundry': 'azure',
-    openrouter: 'openrouter',
-    'github models': 'github',
-  };
-  const providerKey = providerKeyMap[provider.toLowerCase()] ?? 'anthropic';
-
-  // 5. API key
-  const envKey = PROVIDER_ENV_KEYS[providerKey];
-  let apiKey = '';
-  if (!process.env[envKey]) {
-    apiKey = await deps.prompt(`Paste your ${provider} API key (${envKey})`);
-  } else {
-    deps.log(`  ${envKey} is already set in your environment.`);
+  const detectedLoginRoute = scan?.hints.authHints.loginRoutes[0];
+  if (detectedLoginRoute) {
+    deps.log(`  (Detected possible login route: ${detectedLoginRoute})`);
   }
+  const requiresLogin = await deps.confirm(
+    'Does the app require login?',
+    Boolean(detectedLoginRoute)
+  );
+
+  // 4-5. Provider + API key
+  const { providerKey, envKey, apiKey } = await selectProvider(deps);
 
   // 6. Headless
   const headless = await deps.confirm('Run browser in headless mode?', false);
 
-  // 7. Save config
+  // 7. Feature toggles suggested by the repo scan
+  let enableApiTesting = false;
+  let enableAdversarial = false;
+  if (scan !== null) {
+    if (scan.hints.apiEndpoints.length > 0) {
+      enableApiTesting = await deps.confirm(
+        `Enable API contract testing? (${scan.hints.apiEndpoints.length} endpoint(s) detected)`,
+        true
+      );
+      enableAdversarial = await deps.confirm(
+        'Enable adversarial security probes against detected API endpoints?',
+        false
+      );
+    }
+  }
+
+  // 8. Save config
   const saveConfig = await deps.confirm('Save config to dramaturge.config.json?', true);
 
   // Build config
   const models = PROVIDER_MODELS[providerKey];
+  const detectedLoginPath = scan?.hints.authHints.loginRoutes[0];
+  const loginUrl =
+    requiresLogin && detectedLoginPath
+      ? new URL(detectedLoginPath, targetUrl).toString()
+      : targetUrl;
+  const successIndicator = `url:${new URL(targetUrl).origin}`;
+
   const config: Record<string, unknown> = {
     targetUrl,
     appDescription: appDescription || `Web application at ${new URL(targetUrl).hostname}`,
     auth: requiresLogin
       ? {
           type: 'interactive',
-          loginUrl: targetUrl,
-          successIndicator: `url:${new URL(targetUrl).origin}`,
+          loginUrl,
+          successIndicator,
           stateFile: './.dramaturge-state/user.json',
           manualTimeoutSeconds: 120,
         }
@@ -152,42 +228,26 @@ export async function runSetup(deps: SetupDependencies): Promise<number> {
     },
   };
 
-  // Write config
-  if (saveConfig) {
-    const configPath = resolve(deps.cwd, 'dramaturge.config.json');
-    if (existsSync(configPath)) {
-      const overwrite = await deps.confirm(
-        'dramaturge.config.json already exists. Overwrite?',
-        false
-      );
-      if (!overwrite) {
-        deps.log('Skipping config write.');
-      } else {
-        writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-        deps.log(`\nWrote ${configPath}`);
-      }
-    } else {
-      writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-      deps.log(`\nWrote ${configPath}`);
-    }
+  if (scan !== null) {
+    const relRoot = toRelativeRoot(deps.cwd, scan.root);
+    config.repoContext = {
+      root: relRoot,
+      framework: scan.framework,
+    };
   }
 
-  // Write .env if API key was provided
-  if (apiKey) {
-    const envPath = resolve(deps.cwd, '.env');
-    const envLine = `${envKey}=${apiKey}\n`;
+  if (enableApiTesting) {
+    config.apiTesting = { enabled: true };
+  }
+  if (enableAdversarial) {
+    config.adversarial = { enabled: true };
+  }
 
-    if (existsSync(envPath)) {
-      deps.log(`\nAdd this to your .env:\n  ${envKey}=<your-key>`);
-    } else {
-      const saveEnv = await deps.confirm('Save API key to .env file?', true);
-      if (saveEnv) {
-        mkdirSync(dirname(envPath), { recursive: true });
-        writeFileSync(envPath, envLine);
-        deps.log(`Wrote ${envPath}`);
-        deps.log('  (Add .env to your .gitignore!)');
-      }
-    }
+  if (saveConfig) {
+    await writeConfigFile(deps, config);
+  }
+  if (apiKey) {
+    await writeEnvFile(deps, envKey, apiKey);
   }
 
   // Next steps
@@ -205,4 +265,148 @@ export async function runSetup(deps: SetupDependencies): Promise<number> {
   deps.log('');
 
   return 0;
+}
+
+interface ProviderChoice {
+  provider: string;
+  providerKey: string;
+  envKey: string;
+  apiKey: string;
+}
+
+async function selectProvider(deps: SetupDependencies): Promise<ProviderChoice> {
+  const provider = await deps.select('Which LLM provider do you want to use?', [
+    'Anthropic',
+    'OpenAI',
+    'Google',
+    'Azure AI Foundry',
+    'OpenRouter',
+    'GitHub Models',
+  ]);
+  const providerKeyMap: Record<string, string> = {
+    anthropic: 'anthropic',
+    openai: 'openai',
+    google: 'google',
+    'azure ai foundry': 'azure',
+    openrouter: 'openrouter',
+    'github models': 'github',
+  };
+  const providerKey = providerKeyMap[provider.toLowerCase()] ?? 'anthropic';
+  const envKey = PROVIDER_ENV_KEYS[providerKey];
+
+  let apiKey = '';
+  if (!process.env[envKey]) {
+    apiKey = await deps.prompt(`Paste your ${provider} API key (${envKey})`);
+  } else {
+    deps.log(`  ${envKey} is already set in your environment.`);
+  }
+
+  return { provider, providerKey, envKey, apiKey };
+}
+
+async function writeConfigFile(
+  deps: SetupDependencies,
+  config: Record<string, unknown>
+): Promise<void> {
+  const configPath = resolve(deps.cwd, 'dramaturge.config.json');
+  if (existsSync(configPath)) {
+    const overwrite = await deps.confirm(
+      'dramaturge.config.json already exists. Overwrite?',
+      false
+    );
+    if (!overwrite) {
+      deps.log('Skipping config write.');
+      return;
+    }
+  }
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+  deps.log(`\nWrote ${configPath}`);
+}
+
+async function writeEnvFile(
+  deps: SetupDependencies,
+  envKey: string,
+  apiKey: string
+): Promise<void> {
+  const envPath = resolve(deps.cwd, '.env');
+  const envLine = `${envKey}=${apiKey}\n`;
+
+  if (existsSync(envPath)) {
+    deps.log(`\nAdd this to your .env:\n  ${envKey}=<your-key>`);
+    return;
+  }
+  const saveEnv = await deps.confirm('Save API key to .env file?', true);
+  if (!saveEnv) return;
+  mkdirSync(dirname(envPath), { recursive: true });
+  writeFileSync(envPath, envLine);
+  deps.log(`Wrote ${envPath}`);
+  deps.log('  (Add .env to your .gitignore!)');
+}
+
+async function maybeRunRepoScan(
+  deps: SetupDependencies,
+  args: SetupArgs
+): Promise<RepoScanResult | null> {
+  // Explicit opt-out
+  if (args.repoPath === false) return null;
+
+  let root: string | undefined;
+  if (typeof args.repoPath === 'string' && args.repoPath.length > 0) {
+    root = isAbsolute(args.repoPath) ? args.repoPath : resolve(deps.cwd, args.repoPath);
+  } else {
+    const gitRoot = findGitRoot(deps.cwd);
+    if (gitRoot) root = gitRoot;
+  }
+
+  if (!root) return null;
+  if (!existsSync(root)) {
+    deps.error(`Repo path not found: ${root}`);
+    return null;
+  }
+
+  const scanFn = deps.scanRepo ?? defaultScan;
+  let result: RepoScanResult;
+  try {
+    result = scanFn(root);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    deps.error(`Repo scan failed: ${message}`);
+    return null;
+  }
+
+  reportScan(deps.log, result);
+
+  // When no hints were extracted we still keep the result if a concrete framework was detected,
+  // so the generated config preserves `repoContext.framework` for the engine to use at runtime.
+  if (!hintsAreMeaningful(result.hints)) {
+    if (result.framework === 'generic') {
+      deps.log('  (No routes or endpoints detected — proceeding with a generic config.)\n');
+      return null;
+    }
+    deps.log(`  (No routes extracted, but framework detected — recording framework only.)\n`);
+    return result;
+  }
+
+  const useScan = await deps.confirm('Use these detected hints in the generated config?', true);
+  if (!useScan) return null;
+
+  return result;
+}
+
+function reportScan(log: (message: string) => void, scan: RepoScanResult): void {
+  log(`\nScanning repo at ${scan.root}`);
+  log(`  framework: ${FRAMEWORK_LABELS[scan.framework]}`);
+  log(`  routes detected: ${scan.hints.routes.length}`);
+  log(`  route families: ${scan.hints.routeFamilies.length}`);
+  log(`  API endpoints: ${scan.hints.apiEndpoints.length}`);
+  log(`  login routes: ${scan.hints.authHints.loginRoutes.length}`);
+  log(`  callback routes: ${scan.hints.authHints.callbackRoutes.length}`);
+  log('');
+}
+
+function toRelativeRoot(cwd: string, root: string): string {
+  if (root === cwd) return '.';
+  const rel = relative(cwd, root);
+  if (!rel || rel.startsWith('..')) return root;
+  return rel;
 }


### PR DESCRIPTION
Changes:
  - src/commands/setup.ts — runs optional repo scan, reports detected framework/routes/endpoints/auth hints, suggests
  feature toggles (apiTesting, adversarial) and a login route, injects repoContext into generated config. Extracted
  helpers to keep runSetup readable.
  - src/cli.ts — adds --repo <path> and --no-scan flags; rejects next-flag-as-value; errors when both are combined; help
   text updated.
  - src/adaptation/repo-scan.ts — exported the existing detectFramework so setup can surface the framework label.
  - src/commands/setup.test.ts — 10 new tests covering auto-detect, explicit --repo, --no-scan, upward .git traversal,
  empty-hints-with-framework case, invalid URL, missing path, overwrite prompt.
  - src/cli.test.ts — tests for --repo, --no-scan, missing value, adjacent-flag misuse, and combined-flag rejection.