### PR TITLE
bootstrap safe exec modes

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -121,7 +121,143 @@ describe('loadConfig', () => {
       readyUrl: 'https://example.com/health',
       readyIndicator: "[data-testid='app-shell']",
       timeoutSeconds: 90,
+      mode: 'trusted',
+      args: [],
     });
+  });
+
+  it('accepts safe-mode bootstrap with structured command and args', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      `{
+        "targetUrl": "https://example.com/app",
+        "appDescription": "Test app",
+        "auth": { "type": "none" },
+        "bootstrap": {
+          "mode": "safe",
+          "command": "pnpm",
+          "args": ["dev", "--port", "3000"]
+        }
+      }`,
+      'utf-8'
+    );
+
+    const config = loadConfig(configPath);
+
+    expect(config.bootstrap).toMatchObject({
+      mode: 'safe',
+      command: 'pnpm',
+      args: ['dev', '--port', '3000'],
+    });
+  });
+
+  it('accepts safe-mode args that contain characters that would be unsafe under a shell', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      `{
+        "targetUrl": "https://example.com/app",
+        "appDescription": "Test app",
+        "auth": { "type": "none" },
+        "bootstrap": {
+          "mode": "safe",
+          "command": "node",
+          "args": ["-e", "console.log('hi; rm -rf /')"]
+        }
+      }`,
+      'utf-8'
+    );
+
+    const config = loadConfig(configPath);
+
+    expect(config.bootstrap).toMatchObject({
+      mode: 'safe',
+      command: 'node',
+      args: ['-e', "console.log('hi; rm -rf /')"],
+    });
+  });
+
+  it('rejects safe-mode commands that contain whitespace', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      `{
+        "targetUrl": "https://example.com/app",
+        "appDescription": "Test app",
+        "auth": { "type": "none" },
+        "bootstrap": {
+          "mode": "safe",
+          "command": "pnpm dev"
+        }
+      }`,
+      'utf-8'
+    );
+
+    expect(() => loadConfig(configPath)).toThrow(/whitespace is not allowed/);
+  });
+
+  it('rejects safe-mode bootstrap commands that contain shell metacharacters', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      `{
+        "targetUrl": "https://example.com/app",
+        "appDescription": "Test app",
+        "auth": { "type": "none" },
+        "bootstrap": {
+          "mode": "safe",
+          "command": "pnpm dev && tail log"
+        }
+      }`,
+      'utf-8'
+    );
+
+    expect(() => loadConfig(configPath)).toThrow(/shell metacharacters/);
+  });
+
+  it('rejects args when bootstrap mode is trusted', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      `{
+        "targetUrl": "https://example.com/app",
+        "appDescription": "Test app",
+        "auth": { "type": "none" },
+        "bootstrap": {
+          "mode": "trusted",
+          "command": "pnpm dev",
+          "args": ["--port", "3000"]
+        }
+      }`,
+      'utf-8'
+    );
+
+    expect(() => loadConfig(configPath)).toThrow(/bootstrap\.args may only be set/);
+  });
+
+  it('requires bootstrap.command when mode is safe', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      `{
+        "targetUrl": "https://example.com/app",
+        "appDescription": "Test app",
+        "auth": { "type": "none" },
+        "bootstrap": {
+          "mode": "safe"
+        }
+      }`,
+      'utf-8'
+    );
+
+    expect(() => loadConfig(configPath)).toThrow(/bootstrap\.command is required/);
   });
 
   it('accepts explicit policy controls', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -437,15 +437,57 @@ const RepoContextSchema = z
   })
   .optional();
 
+const SHELL_METACHARACTER_PATTERN = /[|&;<>$`\\"'()*?{}[\]!#~\n\r]/;
+
+function containsShellMetacharacters(command: string | undefined): boolean {
+  if (!command) {
+    return false;
+  }
+  return SHELL_METACHARACTER_PATTERN.test(command);
+}
+
 const BootstrapSchema = z
   .object({
+    mode: z.enum(['trusted', 'safe']).default('trusted'),
     command: z.string().optional(),
+    args: z.array(z.string()).default([]),
     cwd: z.string().optional(),
     readyUrl: z.string().optional(),
     readyIndicator: z.string().optional(),
     timeoutSeconds: z.number().int().min(5).default(120),
   })
+  .refine((value) => value.mode !== 'trusted' || value.args.length === 0, {
+    message:
+      "bootstrap.args may only be set when bootstrap.mode is 'safe'; in 'trusted' mode, embed arguments in the shell command string instead.",
+    path: ['args'],
+  })
+  .refine((value) => value.mode !== 'safe' || typeof value.command === 'string', {
+    message: "bootstrap.command is required when bootstrap.mode is 'safe'.",
+    path: ['command'],
+  })
+  .refine((value) => value.mode !== 'safe' || !containsShellMetacharacters(value.command), {
+    message:
+      "bootstrap.command in 'safe' mode must be a plain executable path — shell metacharacters are not allowed. Move flags into bootstrap.args, or switch to 'trusted' mode if a shell is required.",
+    path: ['command'],
+  })
+  .refine((value) => value.mode !== 'safe' || !containsWhitespace(value.command), {
+    message:
+      "bootstrap.command in 'safe' mode must be a single executable — whitespace is not allowed. Split the command so that the executable is in bootstrap.command and arguments are in bootstrap.args.",
+    path: ['command'],
+  })
+  .refine((value) => value.mode !== 'safe' || !argsContainNullBytes(value.args), {
+    message: "bootstrap.args in 'safe' mode must not contain null bytes.",
+    path: ['args'],
+  })
   .optional();
+
+function containsWhitespace(command: string | undefined): boolean {
+  return typeof command === 'string' && /\s/.test(command);
+}
+
+function argsContainNullBytes(args: string[] | undefined): boolean {
+  return Array.isArray(args) && args.some((arg) => arg.includes('\0'));
+}
 
 const PolicySchema = z
   .object({

--- a/src/engine/bootstrap.test.ts
+++ b/src/engine/bootstrap.test.ts
@@ -242,6 +242,54 @@ describe('bootstrap supervision', () => {
     killSpy.mockRestore();
   });
 
+  it('spawns safe-mode bootstrap commands without a shell and with structured args', () => {
+    const processRef = createMockProcess();
+    const spawnImpl = vi.fn().mockReturnValue(processRef);
+
+    startBootstrapProcess(
+      {
+        bootstrap: {
+          mode: 'safe',
+          command: 'pnpm',
+          args: ['dev', '--port', '3000'],
+          cwd: '/tmp/app',
+        },
+      } as any,
+      spawnImpl as any,
+      'linux'
+    );
+
+    expect(spawnImpl).toHaveBeenCalledWith('pnpm', ['dev', '--port', '3000'], {
+      cwd: '/tmp/app',
+      detached: true,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  });
+
+  it('defaults to trusted mode and continues to spawn via the shell', () => {
+    const processRef = createMockProcess();
+    const spawnImpl = vi.fn().mockReturnValue(processRef);
+
+    startBootstrapProcess(
+      {
+        bootstrap: {
+          command: 'pnpm dev && tail -f log',
+          cwd: '/tmp/app',
+        },
+      } as any,
+      spawnImpl as any,
+      'linux'
+    );
+
+    expect(spawnImpl).toHaveBeenCalledWith('pnpm dev && tail -f log', {
+      cwd: '/tmp/app',
+      detached: true,
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  });
+
   it('does not attempt cleanup after the bootstrap process has already exited', () => {
     const processRef = createMockProcess();
     const spawnImpl = vi.fn();

--- a/src/engine/bootstrap.ts
+++ b/src/engine/bootstrap.ts
@@ -91,19 +91,36 @@ export function startBootstrapProcess(
   spawnImpl: SpawnLike = spawn,
   platform: NodeJS.Platform = process.platform
 ): BootstrapStatus | undefined {
-  const command = config.bootstrap?.command;
-  if (!command) {
+  const bootstrap = config.bootstrap;
+  const command = bootstrap?.command;
+  if (!bootstrap || !command) {
     return undefined;
   }
 
-  console.log(`Starting bootstrap command: ${command}`);
-  const processRef = spawnImpl(command, {
-    cwd: config.bootstrap?.cwd,
-    detached: platform !== 'win32',
-    shell: true,
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  const status = createBootstrapStatus(processRef, command);
+  const mode = bootstrap.mode ?? 'trusted';
+  const args = bootstrap.args ?? [];
+  const useShell = mode === 'trusted';
+  const displayCommand = useShell
+    ? command
+    : args.length > 0
+      ? `${command} ${args.join(' ')}`
+      : command;
+
+  console.log(`Starting bootstrap command (${mode} mode): ${displayCommand}`);
+  const processRef = useShell
+    ? spawnImpl(command, {
+        cwd: bootstrap.cwd,
+        detached: platform !== 'win32',
+        shell: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+    : spawnImpl(command, args, {
+        cwd: bootstrap.cwd,
+        detached: platform !== 'win32',
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+  const status = createBootstrapStatus(processRef, displayCommand);
 
   attachLogStream(processRef.stdout, status.recentStdout);
   attachLogStream(processRef.stderr, status.recentStderr);


### PR DESCRIPTION
Changes:
  - src/config.ts — BootstrapSchema gains mode: 'trusted' | 'safe' (default trusted, preserves backwards compat) and
  args: string[]. Four refinements: (1) args only allowed in safe mode, (2) command required in safe mode, (3) no shell
  metacharacters in safe command, (4) no whitespace in safe command, (5) no null bytes in args.
  - src/engine/bootstrap.ts — startBootstrapProcess branches: trusted keeps shell: true behavior; safe uses spawn(cmd,
  args, { shell: false }).
  - src/config.test.ts — 5 new schema tests (valid safe config, whitespace/metachar rejection, required command,
  trusted+args rejection, deliberately-unfiltered args accepted).
  - src/engine/bootstrap.test.ts — 2 new spawn-behavior tests (safe mode with structured args; trusted default still
  uses shell).