### PR TITLE
fix: publish npm with OIDC and scoped GitHub package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     if: >-
@@ -27,22 +30,26 @@ jobs:
           node-version: 22.14.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-          registry-url: https://registry.npmjs.org
 
-      - name: Update npm CLI
-        run: npm install --global npm@11.5.1
+      - name: Update npm CLI for trusted publishing
+        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm run test
 
       - name: Build package
-        run: pnpm build
+        run: pnpm run build
 
-      - name: Publish package
-        run: npm publish --provenance
+      - name: Publish package to npm with OIDC
+        run: |
+          npm config delete //registry.npmjs.org/:_authToken --location=user || true
+          unset NODE_AUTH_TOKEN
+          npm publish --provenance --access public --registry https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ''
 
   publish-github-packages:
     if: >-
@@ -72,17 +79,17 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm run test
 
       - name: Build package
-        run: pnpm build
+        run: pnpm run build
 
       - name: Rewrite package metadata for GitHub Packages
         run: |
           npm pkg set name=@aram10/dramaturge
           npm pkg set publishConfig.registry=https://npm.pkg.github.com
 
-      - name: Publish to GitHub Packages
+      - name: Publish package to GitHub Packages
         run: pnpm publish --no-git-checks --registry https://npm.pkg.github.com
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Forces the npmjs.org publish path onto Trusted Publishing/OIDC by removing `setup-node`'s npm registry auth setup from the npm job and clearing any inherited `NODE_AUTH_TOKEN` before `npm publish`.
- Keeps npmjs.org package metadata as unscoped `dramaturge` with the npm registry from `package.json`.
- Keeps GitHub Packages publishing in the same workflow by rewriting the package name to `@aram10/dramaturge` and publishing with the repository `GITHUB_TOKEN`.
- Normalizes publish jobs to pnpm install/test/build commands.

## Why
The failed npm publish reached `npm publish` with token-oriented auth (`NODE_AUTH_TOKEN` in the step environment) and returned `E404`/permission failure for `dramaturge@0.6.0`. npm Trusted Publishing should authenticate via GitHub OIDC instead of a long-lived npm token.

## Verification
- Parsed `.github/workflows/publish.yml` with the repo's `yaml` dependency and asserted both jobs + required permissions.
- Forbidden-pattern check for `secrets.NPM_TOKEN` and `npm ci`.
- Asserted package metadata remains npmjs-ready and GitHub Packages rewrite target is `@aram10/dramaturge`.
- `pnpm exec prettier --check .github/workflows/publish.yml` ✅
- `npm publish --dry-run --access public --registry https://registry.npmjs.org` ✅
- `pnpm run lint` ✅ (existing warnings only)

References:
- npm Trusted Publishing requires OIDC `id-token: write` and npm CLI 11.5.1+/Node 22.14.0+: https://docs.npmjs.com/trusted-publishers/
- GitHub Packages requires scoped npm package names and supports publishing from Actions with `GITHUB_TOKEN`: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry
