### PR TITLE
feat: add confirm replay manifest foundation

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -265,6 +265,30 @@ describe('parseCliArgs', () => {
     });
   });
 
+  it('parses confirm command arguments', () => {
+    const result = parseCliArgs([
+      'confirm',
+      '--finding',
+      'BUG-0042',
+      '--from-report',
+      './reports/run-1',
+      '--format',
+      'short',
+    ]);
+    expect(result).toMatchObject({
+      command: 'confirm',
+      confirmFinding: 'BUG-0042',
+      confirmFromReport: './reports/run-1',
+      confirmFormat: 'short',
+    });
+  });
+
+  it('throws for invalid confirm format', () => {
+    expect(() => parseCliArgs(['confirm', '--finding', 'BUG-0042', '--format', 'sarif'])).toThrow(
+      'Invalid confirm format'
+    );
+  });
+
   it('parses --profile flag', () => {
     const result = parseCliArgs(['run', 'https://example.com', '--profile', 'admin']);
     expect(result.profile).toBe('admin');
@@ -515,6 +539,22 @@ describe('runCli', () => {
 
     expect(exitCode).toBe(0);
     expect(runMcpServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes confirm command without loading run config', async () => {
+    const output: string[] = [];
+    const errors: string[] = [];
+
+    const exitCode = await runCli(['confirm', '--finding', 'BUG-4042', '--from-report', '.'], {
+      loadConfig: vi.fn(),
+      runEngine: vi.fn(),
+      log: (message) => output.push(message),
+      error: (message) => errors.push(message),
+    });
+
+    expect(exitCode).toBe(2);
+    expect(output).toEqual([]);
+    expect(errors.join('\n')).toContain('No replay manifest found for BUG-4042');
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ import { runDoctor } from './commands/doctor.js';
 import { runInit, type InitTemplate } from './commands/init.js';
 import { runTriageCommand } from './commands/triage.js';
 import { runBenchmarkCommand as runBenchmarkCommandImpl } from './commands/benchmark.js';
+import { runConfirmCommand, type ConfirmOutputFormat } from './commands/confirm.js';
 import type {
   ErrorEvent,
   FindingEvent,
@@ -43,6 +44,7 @@ export interface ParsedCliArgs {
     | 'baselines'
     | 'memory'
     | 'benchmark'
+    | 'confirm'
     | 'help';
   configPath?: string;
   resumeDir?: string;
@@ -93,6 +95,12 @@ export interface ParsedCliArgs {
   benchmarkSave?: boolean;
   /** --output flag for benchmark command */
   benchmarkOutput?: string;
+  /** --finding flag for confirm command */
+  confirmFinding?: string;
+  /** --from-report flag for confirm command */
+  confirmFromReport?: string;
+  /** --format flag for confirm command */
+  confirmFormat?: ConfirmOutputFormat;
 }
 
 export interface CliDependencies {
@@ -117,6 +125,7 @@ Commands:
   baselines <sub>      Manage visual-regression baselines (list | approve)
   memory stats         Show memory store statistics
   benchmark [app-id]   Run signal-to-noise benchmarks against well-known apps
+  confirm              Confirm whether a previous finding still reproduces
 
 Run options:
   --config <path>      Path to config file (default: dramaturge.config.json)
@@ -161,6 +170,11 @@ Benchmark options:
   --save               Save benchmark results to disk
   --output <dir>       Output directory for benchmark results (default: ./benchmarks/results)
 
+Confirm options:
+  --finding <id>       Finding ID to confirm (for example BUG-0042)
+  --from-report <dir>  Report directory containing findings/<id>.json
+  --format <format>    Output format: markdown, json, or short
+
 Examples:
   dramaturge run https://my-app.example.com           # Quick run, no config needed
   dramaturge run https://my-app.example.com --login    # Run with interactive auth
@@ -179,6 +193,7 @@ Examples:
   dramaturge findings suppress abc123 --reason "known issue"
   dramaturge baselines approve --all                   # Recapture all visual baselines
   dramaturge memory stats                              # Summarize memory store
+  dramaturge confirm --finding BUG-0042 --from-report ./dramaturge-reports/latest
 
 Environment variables:
   ANTHROPIC_API_KEY              API key for Anthropic models
@@ -216,6 +231,7 @@ const KNOWN_COMMANDS = new Set([
   'baselines',
   'memory',
   'benchmark',
+  'confirm',
 ]);
 const TRIAGE_COMMANDS = new Set(['findings', 'baselines', 'memory']);
 const VALID_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'azure', 'openrouter', 'github']);
@@ -228,6 +244,8 @@ const VALUE_FLAGS = new Set([
   '--diff',
   '--url',
   '--output',
+  '--from-report',
+  '--finding',
   '--reason',
   '--provider',
   '--preset',
@@ -374,11 +392,13 @@ function parseWithYargs(args: readonly string[]) {
     .option('provider', { type: 'string', coerce: parseProvider })
     .option('preset', { type: 'string', coerce: parsePreset })
     .option('focus', { type: 'string', array: true, coerce: parseFocusModes })
-    .option('format', { type: 'string', coerce: parseFormatValue })
+    .option('format', { type: 'string' })
     .option('profile', { type: 'string' })
     .option('template', { type: 'string', coerce: parseTemplate })
     .option('url', { type: 'string' })
     .option('output', { type: 'string' })
+    .option('from-report', { type: 'string' })
+    .option('finding', { type: 'string' })
     .option('repo', { type: 'string' })
     .option('no-scan', { type: 'boolean' })
     .option('suppressed', { type: 'boolean' })
@@ -422,6 +442,13 @@ function parseFormatValue(value: string): NonNullable<ParsedCliArgs['formats']> 
   return parts as NonNullable<ParsedCliArgs['formats']>;
 }
 
+function parseConfirmFormatValue(value: string): ConfirmOutputFormat {
+  if (value === 'markdown' || value === 'json' || value === 'short') {
+    return value;
+  }
+  throw new Error(`Invalid confirm format: ${value}. Must be one of: markdown, json, short`);
+}
+
 export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   if (args.includes('--help') || args.includes('-h')) {
     return { command: 'help', dashboard: false, showHelp: true };
@@ -429,12 +456,19 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
 
   assertValueFlagsHaveValues(args);
   const argv = parseWithYargs(args);
-  const positionals = argv._.map((value) => String(value));
+  const positionals = argv._.map((value: unknown) => String(value));
   const positionalArgs = parsePositionals(positionals, argv.url);
   const provider = argv.provider as ParsedCliArgs['provider'] | undefined;
   const preset = argv.preset as ParsedCliArgs['preset'] | undefined;
   const focusModes = argv.focus as FocusMode[] | undefined;
-  const formats = argv.format as ParsedCliArgs['formats'] | undefined;
+  const formats =
+    positionalArgs.command === 'confirm' || !argv.format
+      ? undefined
+      : parseFormatValue(String(argv.format));
+  const confirmFormat =
+    positionalArgs.command === 'confirm' && argv.format
+      ? parseConfirmFormatValue(String(argv.format))
+      : undefined;
   const initTemplate = argv.template as InitTemplate | undefined;
   const repoPath = argv.repo;
   const noScan = argv.noScan || undefined;
@@ -482,6 +516,13 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
           benchmarkAppId: positionalArgs.benchmarkAppId,
           benchmarkSave: argv.save ?? undefined,
           benchmarkOutput: argv.output,
+        }
+      : {}),
+    ...(positionalArgs.command === 'confirm'
+      ? {
+          confirmFinding: argv.finding,
+          confirmFromReport: argv.fromReport,
+          confirmFormat,
         }
       : {}),
   };
@@ -557,6 +598,23 @@ export async function runCli(
 
       case 'benchmark':
         return await runBenchmarkCommand(dependencies, parsedArgs);
+
+      case 'confirm':
+        return await runConfirmCommand(
+          {
+            finding: parsedArgs.confirmFinding,
+            fromReport: parsedArgs.confirmFromReport,
+            format: parsedArgs.confirmFormat,
+            configPath: parsedArgs.configPath,
+            profile: parsedArgs.profile,
+          },
+          {
+            log: dependencies.log,
+            error: dependencies.error,
+            cwd: process.cwd(),
+            loadConfig: dependencies.loadConfig,
+          }
+        );
 
       default:
         dependencies.error(`Unknown command: ${parsedArgs.command}`);

--- a/src/commands/confirm.test.ts
+++ b/src/commands/confirm.test.ts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runConfirmCommand, type ConfirmDependencies } from './confirm.js';
+import type { ConfirmationResult } from '../types.js';
+import type { FindingReplayManifest } from '../repro/manifest.js';
+
+function makeManifest(): FindingReplayManifest {
+  return {
+    schemaVersion: 1,
+    finding: {
+      id: 'BUG-0001',
+      signature: '["Bug","Major","Submit fails","ok","bad"]',
+      category: 'Bug',
+      severity: 'Major',
+      title: 'Submit fails',
+      expected: 'ok',
+      actual: 'bad',
+      evidenceTypes: ['console-error'],
+    },
+    origin: {
+      runStartedAt: '2026-05-20T18:00:00.000Z',
+      targetUrl: 'https://example.com',
+    },
+    replay: {
+      actions: [],
+      breadcrumbs: [],
+      objective: 'Confirm submit failure',
+      maxStepsBudget: 1,
+    },
+    oracles: { consoleErrorFragments: ['Cannot read properties of null'] },
+  };
+}
+
+function makeResult(verdict: ConfirmationResult['verdict']): ConfirmationResult {
+  return {
+    findingId: 'BUG-0001',
+    signature: 'sig',
+    verdict,
+    confidence: verdict === 'cannot_confirm' ? 'low' : 'high',
+    origin: { runStartedAt: '2026-05-20T18:00:00.000Z', targetUrl: 'https://example.com' },
+    replay: { actionsRequested: 1, actionsCompleted: verdict === 'cannot_confirm' ? 0 : 1 },
+    oracleComparison: {
+      consoleErrorsOriginal: 1,
+      consoleErrorsCurrent: verdict === 'still_reproducible' ? 1 : 0,
+      networkFailuresOriginal: 0,
+      networkFailuresCurrent: 0,
+      a11yViolationsOriginal: 0,
+      a11yViolationsCurrent: 0,
+    },
+    observedNow: {},
+    evidence: { consoleErrors: [] },
+    durationMs: 0,
+  };
+}
+
+interface Harness {
+  cwd: string;
+  reportDir: string;
+  logs: string[];
+  errors: string[];
+  deps: ConfirmDependencies;
+}
+
+function writeManifest(reportDir: string): void {
+  const findingsDir = join(reportDir, 'findings');
+  mkdirSync(findingsDir, { recursive: true });
+  writeFileSync(join(findingsDir, 'BUG-0001.json'), JSON.stringify(makeManifest(), null, 2));
+}
+
+function makeHarness(result: ConfirmationResult = makeResult('fixed')): Harness {
+  const cwd = mkdtempSync(join(tmpdir(), 'dramaturge-confirm-'));
+  const reportDir = join(cwd, 'reports', 'run-1');
+  writeManifest(reportDir);
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    cwd,
+    reportDir,
+    logs,
+    errors,
+    deps: {
+      cwd,
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+      replayManifest: vi.fn().mockResolvedValue(result),
+    },
+  };
+}
+
+describe('runConfirmCommand', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness();
+  });
+
+  afterEach(() => {
+    rmSync(h.cwd, { recursive: true, force: true });
+  });
+
+  it('returns 0 and renders fixed result', async () => {
+    const code = await runConfirmCommand(
+      { finding: 'BUG-0001', fromReport: h.reportDir, format: 'short' },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(h.logs.join('\n')).toContain('BUG-0001 fixed');
+  });
+
+  it('returns 1 for still_reproducible', async () => {
+    h = makeHarness(makeResult('still_reproducible'));
+
+    const code = await runConfirmCommand(
+      { finding: 'BUG-0001', fromReport: h.reportDir, format: 'json' },
+      h.deps
+    );
+
+    expect(code).toBe(1);
+    expect(JSON.parse(h.logs.join('\n'))).toMatchObject({ verdict: 'still_reproducible' });
+  });
+
+  it('returns 2 for cannot_confirm', async () => {
+    h = makeHarness(makeResult('cannot_confirm'));
+
+    const code = await runConfirmCommand({ finding: 'BUG-0001', fromReport: h.reportDir }, h.deps);
+
+    expect(code).toBe(2);
+    expect(h.logs.join('\n')).toContain('cannot_confirm');
+  });
+
+  it('loads the newest report with findings when --from-report is omitted', async () => {
+    const reportsRoot = join(h.cwd, 'dramaturge-reports');
+    const older = join(reportsRoot, '2026-05-19T00-00-00');
+    const newer = join(reportsRoot, '2026-05-20T00-00-00');
+    writeManifest(older);
+    writeManifest(newer);
+
+    const code = await runConfirmCommand({ finding: 'BUG-0001', format: 'short' }, h.deps);
+
+    expect(code).toBe(0);
+    expect(h.logs.join('\n')).toContain('BUG-0001 fixed');
+  });
+
+  it('loads an explicit config path for future auth-capable replay adapters', async () => {
+    const loadConfig = vi.fn();
+    h.deps.loadConfig = loadConfig;
+
+    const code = await runConfirmCommand(
+      {
+        finding: 'BUG-0001',
+        fromReport: h.reportDir,
+        format: 'short',
+        configPath: 'custom.json',
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(loadConfig).toHaveBeenCalledWith('custom.json');
+  });
+
+  it('passes loaded config and selected profile into replay context', async () => {
+    const config = { targetUrl: 'https://example.com' };
+    const replayManifest = vi.fn().mockResolvedValue(makeResult('fixed'));
+    h.deps.loadConfig = vi.fn().mockReturnValue(config);
+    h.deps.replayManifest = replayManifest;
+
+    const code = await runConfirmCommand(
+      {
+        finding: 'BUG-0001',
+        fromReport: h.reportDir,
+        configPath: 'custom.json',
+        profile: 'admin',
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(replayManifest).toHaveBeenCalledWith({
+      manifest: expect.objectContaining({ finding: expect.objectContaining({ id: 'BUG-0001' }) }),
+      config,
+      profile: 'admin',
+    });
+  });
+
+  it('returns usage error when finding is missing', async () => {
+    const code = await runConfirmCommand({ fromReport: h.reportDir }, h.deps);
+
+    expect(code).toBe(1);
+    expect(h.errors.join('\n')).toContain('Usage: dramaturge confirm');
+  });
+
+  it('returns a clear error when the manifest is missing', async () => {
+    const code = await runConfirmCommand({ finding: 'BUG-4042', fromReport: h.reportDir }, h.deps);
+
+    expect(code).toBe(2);
+    expect(h.errors.join('\n')).toContain('No replay manifest found for BUG-4042');
+  });
+});

--- a/src/commands/confirm.test.ts
+++ b/src/commands/confirm.test.ts
@@ -96,6 +96,7 @@ describe('runConfirmCommand', () => {
   let h: Harness;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     h = makeHarness();
   });
 

--- a/src/commands/confirm.ts
+++ b/src/commands/confirm.ts
@@ -114,7 +114,9 @@ export async function runConfirmCommand(
   deps: ConfirmDependencies
 ): Promise<number> {
   if (!args.finding) {
-    deps.error('Usage: dramaturge confirm --finding <id> --from-report <report-dir>');
+    deps.error(
+      'Usage: dramaturge confirm --finding <id> [--from-report <report-dir>] (defaults to newest ./dramaturge-reports/*)'
+    );
     return 1;
   }
 

--- a/src/commands/confirm.ts
+++ b/src/commands/confirm.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { ConfirmationResult } from '../types.js';
+import { loadFindingReplayManifest, type FindingReplayManifest } from '../repro/manifest.js';
+import { confirmManifest } from '../repro/replayer.js';
+
+export type ConfirmOutputFormat = 'markdown' | 'json' | 'short';
+
+export interface ConfirmCommandArgs {
+  finding?: string;
+  fromReport?: string;
+  format?: ConfirmOutputFormat;
+  configPath?: string;
+  profile?: string;
+}
+
+export interface ConfirmReplayContext {
+  manifest: FindingReplayManifest;
+  config?: unknown;
+  profile?: string;
+}
+
+export interface ConfirmDependencies {
+  log: (message: string) => void;
+  error: (message: string) => void;
+  cwd: string;
+  loadConfig?: (configPath?: string) => unknown;
+  replayManifest?: (context: ConfirmReplayContext) => Promise<ConfirmationResult>;
+}
+
+function resultExitCode(result: ConfirmationResult): number {
+  switch (result.verdict) {
+    case 'fixed':
+      return 0;
+    case 'still_reproducible':
+      return 1;
+    case 'cannot_confirm':
+      return 2;
+    case 'changed_surface':
+    case 'new_related_issue':
+      return 3;
+  }
+}
+
+function renderShort(result: ConfirmationResult): string {
+  switch (result.verdict) {
+    case 'fixed':
+      return `${result.findingId} fixed (${result.confidence} confidence)`;
+    case 'still_reproducible':
+      return `${result.findingId} still reproducible (${result.confidence} confidence)`;
+    case 'cannot_confirm':
+      return `${result.findingId} cannot confirm (${result.confidence} confidence)`;
+    case 'changed_surface':
+      return `${result.findingId} changed surface (${result.confidence} confidence)`;
+    case 'new_related_issue':
+      return `${result.findingId} new related issue (${result.confidence} confidence)`;
+  }
+}
+
+function renderMarkdown(result: ConfirmationResult): string {
+  const lines = [
+    '# Confirmation Report',
+    '',
+    '| ID | Verdict | Confidence | Replay |',
+    '|----|---------|------------|--------|',
+    `| ${result.findingId} | ${result.verdict} | ${result.confidence} | ${result.replay.actionsCompleted}/${result.replay.actionsRequested} |`,
+    '',
+    `## ${result.findingId} — ${result.verdict}`,
+    `- Replay: ${result.replay.actionsCompleted} of ${result.replay.actionsRequested} actions completed`,
+    `- Console errors: ${result.oracleComparison.consoleErrorsCurrent} current / ${result.oracleComparison.consoleErrorsOriginal} original`,
+    `- Network failures: ${result.oracleComparison.networkFailuresCurrent} current / ${result.oracleComparison.networkFailuresOriginal} original`,
+  ];
+  if (result.replay.stoppedReason) {
+    lines.push(`- Stopped reason: ${result.replay.stoppedReason}`);
+  }
+  return lines.join('\n');
+}
+
+function renderResult(result: ConfirmationResult, format: ConfirmOutputFormat): string {
+  switch (format) {
+    case 'json':
+      return JSON.stringify(result, null, 2);
+    case 'short':
+      return renderShort(result);
+    case 'markdown':
+      return renderMarkdown(result);
+  }
+}
+
+function resolveReportDir(cwd: string, fromReport?: string): string {
+  if (fromReport) return resolve(cwd, fromReport);
+
+  const reportsRoot = resolve(cwd, './dramaturge-reports');
+  if (!existsSync(reportsRoot)) {
+    return join(reportsRoot, 'latest');
+  }
+
+  const latest = readdirSync(reportsRoot)
+    .map((name) => {
+      const path = join(reportsRoot, name);
+      return { path, stats: statSync(path) };
+    })
+    .filter((entry) => entry.stats.isDirectory() && existsSync(join(entry.path, 'findings')))
+    .sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs)[0];
+
+  return latest?.path ?? join(reportsRoot, 'latest');
+}
+
+export async function runConfirmCommand(
+  args: ConfirmCommandArgs,
+  deps: ConfirmDependencies
+): Promise<number> {
+  if (!args.finding) {
+    deps.error('Usage: dramaturge confirm --finding <id> --from-report <report-dir>');
+    return 1;
+  }
+
+  const reportDir = resolveReportDir(deps.cwd, args.fromReport);
+  try {
+    const config = args.configPath ? deps.loadConfig?.(args.configPath) : undefined;
+    const manifest = loadFindingReplayManifest(reportDir, args.finding);
+    const result = deps.replayManifest
+      ? await deps.replayManifest({ manifest, config, profile: args.profile })
+      : await confirmManifest(manifest);
+    deps.log(renderResult(result, args.format ?? 'markdown'));
+    return resultExitCode(result);
+  } catch (error) {
+    deps.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -82,3 +82,6 @@ export const DEFAULT_LLM_TIMEOUT_MS = 30_000;
 
 /** LLM judge request timeout in milliseconds. */
 export const JUDGE_LLM_TIMEOUT_MS = 15_000;
+
+/** Visual diff ratio threshold used to classify changed surfaces. */
+export const VISUAL_CHANGED_SURFACE_RATIO_THRESHOLD = 0.05;

--- a/src/coverage/visual-regression.ts
+++ b/src/coverage/visual-regression.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import pixelmatch from "pixelmatch";
 import { PNG } from "pngjs";
 import { buildConfirmedFindingMeta } from "../repro/repro.js";
-import { shortId } from "../constants.js";
+import { shortId, VISUAL_CHANGED_SURFACE_RATIO_THRESHOLD } from "../constants.js";
 import type { VisualRegressionPage } from "../browser/page-interface.js";
 import type { Evidence, FindingSeverity, RawFinding } from "../types.js";
 import type { MemoryStore } from "../memory/store.js";
@@ -36,7 +36,7 @@ function mapDiffRatioToSeverity(ratio: number): FindingSeverity {
   if (ratio >= 0.25) {
     return "Critical";
   }
-  if (ratio >= 0.05) {
+  if (ratio >= VISUAL_CHANGED_SURFACE_RATIO_THRESHOLD) {
     return "Major";
   }
   if (ratio >= 0.01) {

--- a/src/engine/reports.test.ts
+++ b/src/engine/reports.test.ts
@@ -2,9 +2,12 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { describe, expect, it } from 'vitest';
-import { buildAreaResults } from './reports.js';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildAreaResults, writeReports } from './reports.js';
 import type { EngineContext } from './context.js';
-import type { StateNode, RawFinding, Evidence, ReplayableAction } from '../types.js';
+import type { AreaResult, StateNode, RawFinding, Evidence, ReplayableAction } from '../types.js';
 
 function makeNode(overrides: Partial<StateNode> = {}): StateNode {
   return {
@@ -180,5 +183,117 @@ describe('buildAreaResults', () => {
 
     expect(results[0].pageType).toBe('dashboard');
     expect(results[0].fingerprint).toEqual(node.fingerprint);
+  });
+});
+
+function makeAreaResultForReport(): AreaResult {
+  const action: ReplayableAction = {
+    id: 'act-1',
+    kind: 'click',
+    summary: 'Click submit button',
+    source: 'page',
+    status: 'recorded',
+    timestamp: '2026-05-20T18:00:00.000Z',
+    selector: 'button.submit',
+  };
+  return {
+    name: 'Checkout',
+    url: 'https://example.com/checkout',
+    steps: 1,
+    findings: [
+      makeFinding({
+        evidenceIds: ['ev-1'],
+        meta: {
+          source: 'agent',
+          confidence: 'high',
+          repro: {
+            route: '/checkout',
+            objective: 'Submit checkout form',
+            breadcrumbs: ['checkout', 'submit'],
+            actionIds: ['act-1'],
+            evidenceIds: ['ev-1'],
+          },
+        },
+      }),
+    ],
+    replayableActions: [action],
+    screenshots: new Map(),
+    evidence: [
+      makeEvidence({
+        id: 'ev-1',
+        type: 'console-error',
+        summary: 'Cannot read properties of null',
+      }),
+    ],
+    coverage: { controlsDiscovered: 1, controlsExercised: 1, events: [] },
+    pageType: 'form',
+    status: 'explored',
+  };
+}
+
+function makeReportContext(outputDir: string): EngineContext {
+  return {
+    outputDir,
+    config: {
+      targetUrl: 'https://example.com',
+      appDescription: 'Example app',
+      models: { planner: 'anthropic/test-planner', worker: 'anthropic/test-worker' },
+      concurrency: { workers: 1 },
+      budget: {
+        globalTimeLimitSeconds: 60,
+        maxStepsPerTask: 3,
+        maxFrontierSize: 10,
+        maxStateNodes: 10,
+      },
+      checkpoint: { intervalTasks: 0 },
+      autoCapture: {
+        consoleErrors: false,
+        consoleWarnings: false,
+        networkErrors: false,
+      },
+      memory: { enabled: false, warmStart: false },
+      visualRegression: { enabled: false },
+      output: { format: 'json' },
+    },
+    budget: {
+      globalTimeLimitSeconds: 60,
+      maxStepsPerTask: 3,
+      maxFrontierSize: 10,
+      maxStateNodes: 10,
+    },
+    globalCoverage: { getBlindSpots: () => [] },
+    graph: { nodeCount: () => 0, toMermaid: () => '' },
+    activeAuthProfile: 'admin',
+    logger: { info: () => undefined },
+  } as unknown as EngineContext;
+}
+
+describe('writeReports', () => {
+  it('emits replay manifests alongside existing report artifacts', () => {
+    const outputDir = mkdtempSync(join(tmpdir(), 'dramaturge-reports-'));
+    try {
+      writeReports(
+        makeReportContext(outputDir),
+        new Date('2026-05-20T18:00:00.000Z'),
+        [makeAreaResultForReport()],
+        []
+      );
+
+      const reportPath = join(outputDir, 'report.json');
+      const manifestPath = join(outputDir, 'findings', 'BUG-001.json');
+      expect(existsSync(reportPath)).toBe(true);
+      expect(existsSync(manifestPath)).toBe(true);
+
+      const report = JSON.parse(readFileSync(reportPath, 'utf-8')) as { findings: unknown[] };
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as {
+        origin: { authProfile?: string };
+        replay: { actions: ReplayableAction[] };
+      };
+      expect(report.findings).toHaveLength(1);
+      expect(manifest.origin.authProfile).toBe('admin');
+      expect(manifest.replay.actions.map((action) => action.id)).toEqual(['act-1']);
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/engine/reports.ts
+++ b/src/engine/reports.ts
@@ -11,6 +11,7 @@ import { renderJson } from '../report/json.js';
 import { renderJunit } from '../report/junit.js';
 import { renderSarif } from '../report/sarif.js';
 import { writeGeneratedPlaywrightTests } from '../report/test-gen.js';
+import { writeFindingReplayManifests } from '../repro/manifest.js';
 import { resolveOutputFormats } from '../config.js';
 import { hasLLMApiKey } from '../llm.js';
 import type { DiffSummary } from '../types.js';
@@ -120,6 +121,9 @@ export function writeReports(
     }
   );
   const generatedTests = writeGeneratedPlaywrightTests(ctx.outputDir, runResult);
+  const replayManifestPaths = writeFindingReplayManifests(ctx.outputDir, runResult, {
+    authProfile: ctx.activeAuthProfile,
+  });
 
   const formats = resolveOutputFormats(config.output.format);
   let firstFormatLogged = false;
@@ -138,6 +142,12 @@ export function writeReports(
     ctx.logger?.info('Generated Playwright tests', {
       count: generatedTests.length,
       path: join(ctx.outputDir, 'generated-tests'),
+    });
+  }
+  if (replayManifestPaths.length > 0) {
+    ctx.logger?.info('Wrote finding replay manifests', {
+      count: replayManifestPaths.length,
+      path: join(ctx.outputDir, 'findings'),
     });
   }
 }

--- a/src/repro/manifest.test.ts
+++ b/src/repro/manifest.test.ts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Evidence, RawFinding, ReplayableAction, RunResult } from '../types.js';
+import {
+  buildFindingReplayManifests,
+  loadFindingReplayManifest,
+  writeFindingReplayManifests,
+} from './manifest.js';
+
+function makeAction(overrides: Partial<ReplayableAction> = {}): ReplayableAction {
+  return {
+    id: 'act-1',
+    kind: 'click',
+    summary: 'Click submit',
+    source: 'page',
+    status: 'recorded',
+    timestamp: '2026-05-20T18:00:00.000Z',
+    selector: 'button[type="submit"]',
+    ...overrides,
+  };
+}
+
+function makeEvidence(overrides: Partial<Evidence> = {}): Evidence {
+  return {
+    id: 'ev-1',
+    type: 'console-error',
+    summary: 'Cannot read properties of null',
+    timestamp: '2026-05-20T18:01:00.000Z',
+    relatedFindingIds: ['fid-1'],
+    ...overrides,
+  };
+}
+
+function makeFinding(overrides: Partial<RawFinding> = {}): RawFinding {
+  return {
+    ref: 'fid-1',
+    category: 'Bug',
+    severity: 'Major',
+    title: 'Submit fails',
+    stepsToReproduce: ['Open checkout', 'Click submit'],
+    expected: 'Order is submitted',
+    actual: 'Console error appears',
+    evidenceIds: ['ev-1', 'ev-2'],
+    meta: {
+      source: 'agent',
+      confidence: 'high',
+      repro: {
+        route: '/checkout',
+        objective: 'Submit checkout form',
+        breadcrumbs: ['checkout', 'submit'],
+        actionIds: ['act-1'],
+        evidenceIds: ['ev-1', 'ev-2'],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    targetUrl: 'https://example.com',
+    startTime: new Date('2026-05-20T18:00:00.000Z'),
+    endTime: new Date('2026-05-20T18:02:00.000Z'),
+    areaResults: [
+      {
+        name: 'Checkout',
+        url: 'https://example.com/checkout',
+        steps: 2,
+        findings: [makeFinding()],
+        replayableActions: [makeAction()],
+        screenshots: new Map(),
+        evidence: [
+          makeEvidence(),
+          makeEvidence({
+            id: 'ev-2',
+            type: 'network-error',
+            summary: 'POST /api/orders returned 500',
+          }),
+        ],
+        coverage: { controlsDiscovered: 1, controlsExercised: 1, events: [] },
+        pageType: 'form',
+        status: 'explored',
+      },
+    ],
+    unexploredAreas: [],
+    partial: false,
+    blindSpots: [],
+    ...overrides,
+  };
+}
+
+describe('finding replay manifests', () => {
+  let tempDir: string | undefined;
+
+  afterEach(() => {
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  });
+
+  it('builds manifests with origin, replay, and oracle data', () => {
+    const [manifest] = buildFindingReplayManifests(makeRunResult());
+
+    expect(manifest.finding).toMatchObject({
+      id: 'BUG-001',
+      category: 'Bug',
+      severity: 'Major',
+      title: 'Submit fails',
+      evidenceTypes: ['console-error', 'network-error'],
+    });
+    expect(manifest.origin).toMatchObject({
+      runStartedAt: '2026-05-20T18:00:00.000Z',
+      targetUrl: 'https://example.com',
+      route: '/checkout',
+    });
+    expect(manifest.replay.actions.map((action) => action.id)).toEqual(['act-1']);
+    expect(manifest.replay.breadcrumbs).toEqual(['checkout', 'submit']);
+    expect(manifest.oracles.consoleErrorFragments).toEqual(['Cannot read properties of null']);
+    expect(manifest.oracles.networkFailures).toEqual([{ urlPattern: '/api/orders', status: 500 }]);
+  });
+
+  it('writes and loads a per-finding manifest under findings directory', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'dramaturge-manifest-'));
+
+    const [path] = writeFindingReplayManifests(tempDir, makeRunResult());
+    const raw = JSON.parse(readFileSync(path, 'utf-8')) as unknown;
+    const loaded = loadFindingReplayManifest(tempDir, 'BUG-001');
+
+    expect(raw).toMatchObject({ schemaVersion: 1 });
+    expect(loaded.finding.id).toBe('BUG-001');
+  });
+
+  it('does not broaden replay to every area action when repro action IDs are absent', () => {
+    const [manifest] = buildFindingReplayManifests(
+      makeRunResult({
+        areaResults: [
+          {
+            name: 'Checkout',
+            url: 'https://example.com/checkout',
+            steps: 2,
+            findings: [
+              makeFinding({
+                meta: {
+                  source: 'auto-capture',
+                  confidence: 'medium',
+                  repro: {
+                    route: '/checkout',
+                    objective: 'Investigate captured error',
+                    breadcrumbs: ['checkout'],
+                    evidenceIds: ['ev-1'],
+                  },
+                },
+              }),
+            ],
+            replayableActions: [makeAction()],
+            screenshots: new Map(),
+            evidence: [makeEvidence()],
+            coverage: { controlsDiscovered: 1, controlsExercised: 1, events: [] },
+            pageType: 'form',
+            status: 'explored',
+          },
+        ],
+      }),
+      { authProfile: 'admin' }
+    );
+
+    expect(manifest.origin.authProfile).toBe('admin');
+    expect(manifest.replay.actions).toEqual([]);
+  });
+
+  it('carries accessibility and visual oracle references when current evidence exposes them', () => {
+    const [manifest] = buildFindingReplayManifests(
+      makeRunResult({
+        areaResults: [
+          {
+            name: 'Checkout',
+            url: 'https://example.com/checkout',
+            steps: 2,
+            findings: [makeFinding({ evidenceIds: ['ev-a11y', 'ev-visual'] })],
+            replayableActions: [makeAction()],
+            screenshots: new Map(),
+            evidence: [
+              makeEvidence({
+                id: 'ev-a11y',
+                type: 'accessibility-scan',
+                summary: 'Accessibility rule color-contrast failed',
+              }),
+              makeEvidence({
+                id: 'ev-visual',
+                type: 'visual-diff',
+                summary: 'Visual diff for Checkout',
+                path: 'visual-diffs/abc.png',
+              }),
+            ],
+            coverage: { controlsDiscovered: 1, controlsExercised: 1, events: [] },
+            pageType: 'form',
+            status: 'explored',
+          },
+        ],
+      })
+    );
+
+    expect(manifest.oracles.a11yRuleIds).toEqual(['color-contrast']);
+    expect(manifest.oracles.visualBaselineRef).toBe('visual-diffs/abc.png');
+  });
+
+  it('throws a clear error when a manifest is missing', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'dramaturge-manifest-'));
+
+    expect(() => loadFindingReplayManifest(tempDir, 'BUG-4042')).toThrow(
+      'No replay manifest found for BUG-4042'
+    );
+  });
+});

--- a/src/repro/manifest.test.ts
+++ b/src/repro/manifest.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Evidence, RawFinding, ReplayableAction, RunResult } from '../types.js';
@@ -180,14 +180,19 @@ describe('finding replay manifests', () => {
             name: 'Checkout',
             url: 'https://example.com/checkout',
             steps: 2,
-            findings: [makeFinding({ evidenceIds: ['ev-a11y', 'ev-visual'] })],
+            findings: [
+              makeFinding({
+                expected: 'The page should satisfy accessibility rule color-contrast.',
+                evidenceIds: ['ev-a11y', 'ev-visual'],
+              }),
+            ],
             replayableActions: [makeAction()],
             screenshots: new Map(),
             evidence: [
               makeEvidence({
                 id: 'ev-a11y',
                 type: 'accessibility-scan',
-                summary: 'Accessibility rule color-contrast failed',
+                summary: 'serious: Elements must have sufficient color contrast',
               }),
               makeEvidence({
                 id: 'ev-visual',
@@ -206,6 +211,24 @@ describe('finding replay manifests', () => {
 
     expect(manifest.oracles.a11yRuleIds).toEqual(['color-contrast']);
     expect(manifest.oracles.visualBaselineRef).toBe('visual-diffs/abc.png');
+  });
+
+  it('throws a targeted validation error when a manifest has an invalid shape', () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'dramaturge-manifest-'));
+    const findingsDir = join(tempDir, 'findings');
+    mkdirSync(findingsDir, { recursive: true });
+    writeFileSync(
+      join(findingsDir, 'BUG-0001.json'),
+      JSON.stringify({
+        schemaVersion: 1,
+        finding: { id: 'BUG-0001' },
+      }),
+      'utf-8'
+    );
+
+    expect(() => loadFindingReplayManifest(tempDir, 'BUG-0001')).toThrow(
+      'Invalid finding replay manifest: finding.signature'
+    );
   });
 
   it('throws a clear error when a manifest is missing', () => {

--- a/src/repro/manifest.ts
+++ b/src/repro/manifest.ts
@@ -3,6 +3,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { z } from 'zod';
 import type { Evidence, Finding, ReplayableAction, RunResult } from '../types.js';
 import { buildFindingGroupKey, collectFindings } from '../report/collector.js';
 
@@ -103,7 +104,7 @@ function extractNetworkFailure(
   };
 }
 
-function buildOracles(evidence: Evidence[]): FindingReplayManifest['oracles'] {
+function buildOracles(finding: Finding, evidence: Evidence[]): FindingReplayManifest['oracles'] {
   const consoleErrorFragments = uniqueValues(
     evidence
       .filter((item) => item.type === 'console-error')
@@ -114,11 +115,15 @@ function buildOracles(evidence: Evidence[]): FindingReplayManifest['oracles'] {
     .filter((item) => item.type === 'network-error')
     .map((item) => extractNetworkFailure(item.summary))
     .filter((item): item is { urlPattern: string; status: number } => Boolean(item));
+  const findingA11yRuleId = /accessibility rule ([\w-]+)/i.exec(finding.expected)?.[1];
   const a11yRuleIds = uniqueValues(
-    evidence
-      .filter((item) => item.type === 'accessibility-scan')
-      .map((item) => /accessibility rule ([\w-]+)/i.exec(item.summary)?.[1])
-      .filter((ruleId): ruleId is string => Boolean(ruleId))
+    [
+      ...evidence
+        .filter((item) => item.type === 'accessibility-scan')
+        .map((item) => /accessibility rule ([\w-]+)/i.exec(item.summary)?.[1])
+        .filter((ruleId): ruleId is string => Boolean(ruleId)),
+      ...(findingA11yRuleId ? [findingA11yRuleId] : []),
+    ].filter((ruleId): ruleId is string => Boolean(ruleId))
   );
   const visualBaselineRef = evidence.find((item) => item.type === 'visual-diff')?.path;
   return {
@@ -162,7 +167,7 @@ export function buildFindingReplayManifest(
       objective: finding.meta?.repro?.objective ?? `Confirm ${finding.id}: ${finding.title}`,
       maxStepsBudget: Math.max(actions.length, 1),
     },
-    oracles: buildOracles(evidence),
+    oracles: buildOracles(finding, evidence),
   };
 }
 
@@ -194,23 +199,81 @@ export function writeFindingReplayManifests(
   return paths;
 }
 
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
+const ReplayActionSchema = z.object({
+  id: z.string().min(1),
+  kind: z.string().min(1),
+  summary: z.string(),
+  source: z.enum(['page', 'worker-tool']),
+  status: z.string().min(1),
+  timestamp: z.string().min(1),
+  selector: z.string().optional(),
+  url: z.string().optional(),
+  value: z.string().optional(),
+  redacted: z.boolean().optional(),
+  key: z.string().optional(),
+});
 
-function isString(value: unknown): value is string {
-  return typeof value === 'string';
+const FindingReplayManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  finding: z.object({
+    id: z.string().min(1),
+    signature: z.string().min(1),
+    category: z.string().min(1),
+    severity: z.string().min(1),
+    title: z.string(),
+    expected: z.string(),
+    actual: z.string(),
+    evidenceTypes: z.array(z.string().min(1)),
+  }),
+  origin: z.object({
+    runStartedAt: z.string().min(1),
+    targetUrl: z.string().min(1),
+    route: z.string().optional(),
+    authProfile: z.string().optional(),
+  }),
+  replay: z.object({
+    actions: z.array(ReplayActionSchema),
+    breadcrumbs: z.array(z.string()),
+    objective: z.string().min(1),
+    maxStepsBudget: z.number().int().nonnegative(),
+  }),
+  oracles: z.object({
+    consoleErrorFragments: z.array(z.string()).optional(),
+    networkFailures: z
+      .array(
+        z.object({
+          urlPattern: z.string().min(1),
+          status: z.number().int(),
+        })
+      )
+      .optional(),
+    a11yRuleIds: z.array(z.string().min(1)).optional(),
+    visualBaselineRef: z.string().min(1).optional(),
+  }),
+});
+
+function formatZodIssuePath(path: PropertyKey[]): string {
+  return path
+    .map((segment) =>
+      typeof segment === 'number'
+        ? `[${segment}]`
+        : typeof segment === 'string'
+          ? segment
+          : String(segment)
+    )
+    .join('.');
 }
 
 function parseManifest(value: unknown): FindingReplayManifest {
-  if (!isObject(value) || value.schemaVersion !== 1 || !isObject(value.finding)) {
-    throw new Error('Invalid finding replay manifest: expected schemaVersion 1');
+  const parsed = FindingReplayManifestSchema.safeParse(value);
+  if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0];
+    const path = formatZodIssuePath(firstIssue.path);
+    throw new Error(
+      `Invalid finding replay manifest: ${path ? `${path}: ` : ''}${firstIssue.message}`
+    );
   }
-  const id = value.finding.id;
-  if (!isString(id) || id.length === 0) {
-    throw new Error('Invalid finding replay manifest: missing finding.id');
-  }
-  return value as unknown as FindingReplayManifest;
+  return parsed.data as FindingReplayManifest;
 }
 
 export function readFindingReplayManifest(path: string): FindingReplayManifest {

--- a/src/repro/manifest.ts
+++ b/src/repro/manifest.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Evidence, Finding, ReplayableAction, RunResult } from '../types.js';
+import { buildFindingGroupKey, collectFindings } from '../report/collector.js';
+
+export interface FindingReplayManifest {
+  schemaVersion: 1;
+  finding: {
+    id: string;
+    signature: string;
+    category: Finding['category'];
+    severity: Finding['severity'];
+    title: string;
+    expected: string;
+    actual: string;
+    evidenceTypes: Evidence['type'][];
+  };
+  origin: {
+    runStartedAt: string;
+    targetUrl: string;
+    route?: string;
+    authProfile?: string;
+  };
+  replay: {
+    actions: ReplayableAction[];
+    breadcrumbs: string[];
+    objective: string;
+    maxStepsBudget: number;
+  };
+  oracles: {
+    consoleErrorFragments?: string[];
+    networkFailures?: Array<{ urlPattern: string; status: number }>;
+    a11yRuleIds?: string[];
+    visualBaselineRef?: string;
+  };
+}
+
+export interface FindingReplayManifestOptions {
+  authProfile?: string;
+}
+
+function manifestFileName(findingId: string): string {
+  return `${findingId.replace(/[^A-Za-z0-9_.-]/g, '_')}.json`;
+}
+
+function uniqueValues<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function collectEvidenceForFinding(result: RunResult, finding: Finding): Evidence[] {
+  const wantedIds = new Set([
+    ...(finding.evidenceIds ?? []),
+    ...finding.occurrences.flatMap((occurrence) => occurrence.evidenceIds),
+    ...(finding.meta?.repro?.evidenceIds ?? []),
+  ]);
+  if (wantedIds.size === 0) return [];
+
+  return result.areaResults.flatMap((area) =>
+    area.evidence.filter((evidence) => wantedIds.has(evidence.id))
+  );
+}
+
+function collectActionsForFinding(result: RunResult, finding: Finding): ReplayableAction[] {
+  const actionIds = new Set(finding.meta?.repro?.actionIds ?? []);
+  const allAreaActions = result.areaResults.flatMap((area) => area.replayableActions ?? []);
+  const ledgerActions =
+    result.explorationLedger?.events.flatMap((event) =>
+      event.kind === 'action' ? [event.action] : []
+    ) ?? [];
+  const allActions = [...allAreaActions, ...ledgerActions];
+
+  if (actionIds.size > 0) {
+    const matched = allActions.filter((action) => actionIds.has(action.id));
+    return uniqueActions(matched);
+  }
+
+  return [];
+}
+
+function uniqueActions(actions: ReplayableAction[]): ReplayableAction[] {
+  const seen = new Set<string>();
+  const unique: ReplayableAction[] = [];
+  for (const action of actions) {
+    if (seen.has(action.id)) continue;
+    seen.add(action.id);
+    unique.push(action);
+  }
+  return unique;
+}
+
+function extractNetworkFailure(
+  summary: string
+): { urlPattern: string; status: number } | undefined {
+  const statusMatch = /\b([1-5][0-9]{2})\b/.exec(summary);
+  if (!statusMatch) return undefined;
+  const urlMatch = /(https?:\/\/\S+|\/[\w./:?-]+)/.exec(summary);
+  return {
+    urlPattern: urlMatch?.[1] ?? summary.slice(0, 120),
+    status: Number.parseInt(statusMatch[1], 10),
+  };
+}
+
+function buildOracles(evidence: Evidence[]): FindingReplayManifest['oracles'] {
+  const consoleErrorFragments = uniqueValues(
+    evidence
+      .filter((item) => item.type === 'console-error')
+      .map((item) => item.summary)
+      .filter((summary) => summary.length > 0)
+  );
+  const networkFailures = evidence
+    .filter((item) => item.type === 'network-error')
+    .map((item) => extractNetworkFailure(item.summary))
+    .filter((item): item is { urlPattern: string; status: number } => Boolean(item));
+  const a11yRuleIds = uniqueValues(
+    evidence
+      .filter((item) => item.type === 'accessibility-scan')
+      .map((item) => /accessibility rule ([\w-]+)/i.exec(item.summary)?.[1])
+      .filter((ruleId): ruleId is string => Boolean(ruleId))
+  );
+  const visualBaselineRef = evidence.find((item) => item.type === 'visual-diff')?.path;
+  return {
+    ...(consoleErrorFragments.length > 0 ? { consoleErrorFragments } : {}),
+    ...(networkFailures.length > 0 ? { networkFailures } : {}),
+    ...(a11yRuleIds.length > 0 ? { a11yRuleIds } : {}),
+    ...(visualBaselineRef ? { visualBaselineRef } : {}),
+  };
+}
+
+export function buildFindingReplayManifest(
+  result: RunResult,
+  finding: Finding,
+  options: FindingReplayManifestOptions = {}
+): FindingReplayManifest {
+  const evidence = collectEvidenceForFinding(result, finding);
+  const actions = collectActionsForFinding(result, finding);
+  const route = finding.meta?.repro?.route ?? finding.occurrences.find((item) => item.route)?.route;
+
+  return {
+    schemaVersion: 1,
+    finding: {
+      id: finding.id,
+      signature: buildFindingGroupKey(finding),
+      category: finding.category,
+      severity: finding.severity,
+      title: finding.title,
+      expected: finding.expected,
+      actual: finding.actual,
+      evidenceTypes: uniqueValues(evidence.map((item) => item.type)),
+    },
+    origin: {
+      runStartedAt: result.startTime.toISOString(),
+      targetUrl: result.targetUrl,
+      ...(route ? { route } : {}),
+      ...(options.authProfile ? { authProfile: options.authProfile } : {}),
+    },
+    replay: {
+      actions,
+      breadcrumbs: finding.meta?.repro?.breadcrumbs ?? finding.stepsToReproduce,
+      objective: finding.meta?.repro?.objective ?? `Confirm ${finding.id}: ${finding.title}`,
+      maxStepsBudget: Math.max(actions.length, 1),
+    },
+    oracles: buildOracles(evidence),
+  };
+}
+
+export function buildFindingReplayManifests(
+  result: RunResult,
+  options: FindingReplayManifestOptions = {}
+): FindingReplayManifest[] {
+  return collectFindings(result.areaResults).map((finding) =>
+    buildFindingReplayManifest(result, finding, options)
+  );
+}
+
+export function writeFindingReplayManifests(
+  outputDir: string,
+  result: RunResult,
+  options: FindingReplayManifestOptions = {}
+): string[] {
+  const manifests = buildFindingReplayManifests(result, options);
+  if (manifests.length === 0) return [];
+
+  const findingsDir = join(outputDir, 'findings');
+  mkdirSync(findingsDir, { recursive: true });
+  const paths: string[] = [];
+  for (const manifest of manifests) {
+    const path = join(findingsDir, manifestFileName(manifest.finding.id));
+    writeFileSync(path, JSON.stringify(manifest, null, 2), 'utf-8');
+    paths.push(path);
+  }
+  return paths;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+function parseManifest(value: unknown): FindingReplayManifest {
+  if (!isObject(value) || value.schemaVersion !== 1 || !isObject(value.finding)) {
+    throw new Error('Invalid finding replay manifest: expected schemaVersion 1');
+  }
+  const id = value.finding.id;
+  if (!isString(id) || id.length === 0) {
+    throw new Error('Invalid finding replay manifest: missing finding.id');
+  }
+  return value as unknown as FindingReplayManifest;
+}
+
+export function readFindingReplayManifest(path: string): FindingReplayManifest {
+  return parseManifest(JSON.parse(readFileSync(path, 'utf-8')) as unknown);
+}
+
+export function loadFindingReplayManifest(
+  reportDir: string,
+  findingId: string
+): FindingReplayManifest {
+  const path = join(reportDir, 'findings', manifestFileName(findingId));
+  if (!existsSync(path)) {
+    throw new Error(
+      `No replay manifest found for ${findingId}. Expected ${path}. Re-run Dramaturge to emit findings/<id>.json manifests.`
+    );
+  }
+  return readFindingReplayManifest(path);
+}

--- a/src/repro/oracles.ts
+++ b/src/repro/oracles.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import type { FindingReplayManifest } from './manifest.js';
+import type { CurrentOracleObservation } from './replayer.js';
+
+export interface OracleMatchSummary {
+  originalCount: number;
+  matchedOriginalCount: number;
+  currentCount: number;
+  allOriginalMatched: boolean;
+  hasCurrentFailures: boolean;
+  hasUnexpectedCurrentFailures: boolean;
+  matchRatio: number;
+}
+
+export function compareReplayOracles(
+  manifest: FindingReplayManifest,
+  observed: CurrentOracleObservation
+): OracleMatchSummary {
+  const consoleMatchCount = (manifest.oracles.consoleErrorFragments ?? []).filter((fragment) =>
+    observed.consoleErrors.some((message) => message.includes(fragment))
+  ).length;
+  const networkMatchCount = (manifest.oracles.networkFailures ?? []).filter((failure) =>
+    observed.networkFailures.some(
+      (item) => item.status === failure.status && item.url.includes(failure.urlPattern)
+    )
+  ).length;
+  const a11yMatchCount = (manifest.oracles.a11yRuleIds ?? []).filter((ruleId) =>
+    observed.a11yRuleIds.includes(ruleId)
+  ).length;
+  const originalCount =
+    (manifest.oracles.consoleErrorFragments?.length ?? 0) +
+    (manifest.oracles.networkFailures?.length ?? 0) +
+    (manifest.oracles.a11yRuleIds?.length ?? 0);
+  const matchedOriginalCount = consoleMatchCount + networkMatchCount + a11yMatchCount;
+  const currentCount =
+    observed.consoleErrors.length + observed.networkFailures.length + observed.a11yRuleIds.length;
+
+  return {
+    originalCount,
+    matchedOriginalCount,
+    currentCount,
+    allOriginalMatched: originalCount > 0 && matchedOriginalCount === originalCount,
+    hasCurrentFailures: currentCount > 0,
+    hasUnexpectedCurrentFailures: currentCount > matchedOriginalCount,
+    matchRatio: originalCount > 0 ? matchedOriginalCount / originalCount : 0,
+  };
+}

--- a/src/repro/replayer.test.ts
+++ b/src/repro/replayer.test.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { describe, expect, it } from 'vitest';
+import type { FindingReplayManifest } from './manifest.js';
+import { buildStaticReplayResult, evaluateReplayConfirmation } from './replayer.js';
+
+function makeManifest(overrides: Partial<FindingReplayManifest> = {}): FindingReplayManifest {
+  return {
+    schemaVersion: 1,
+    finding: {
+      id: 'BUG-0001',
+      signature: '["Bug","Major","Submit fails","ok","bad"]',
+      category: 'Bug',
+      severity: 'Major',
+      title: 'Submit fails',
+      expected: 'ok',
+      actual: 'bad',
+      evidenceTypes: ['console-error'],
+    },
+    origin: {
+      runStartedAt: '2026-05-20T18:00:00.000Z',
+      targetUrl: 'https://example.com',
+      route: '/checkout',
+    },
+    replay: {
+      actions: [
+        {
+          id: 'act-1',
+          kind: 'click',
+          summary: 'Click submit',
+          source: 'page',
+          status: 'recorded',
+          timestamp: '2026-05-20T18:00:01.000Z',
+          selector: 'button',
+        },
+      ],
+      breadcrumbs: ['checkout'],
+      objective: 'Submit checkout',
+      maxStepsBudget: 1,
+    },
+    oracles: {
+      consoleErrorFragments: ['Cannot read properties of null'],
+      networkFailures: [{ urlPattern: '/api/orders', status: 500 }],
+    },
+    ...overrides,
+  };
+}
+
+describe('evaluateReplayConfirmation', () => {
+  it('returns fixed when replay completes and original oracles are absent', () => {
+    const manifest = makeManifest();
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: [],
+        networkFailures: [],
+        a11yRuleIds: [],
+      })
+    );
+
+    expect(result.verdict).toBe('fixed');
+    expect(result.confidence).toBe('medium');
+    expect(result.replay.actionsCompleted).toBe(1);
+  });
+
+  it('returns still_reproducible when an original console error is present', () => {
+    const manifest = makeManifest({
+      oracles: { consoleErrorFragments: ['Cannot read properties of null'] },
+    });
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: ['Cannot read properties of null at checkout.js:12'],
+        networkFailures: [],
+        a11yRuleIds: [],
+      })
+    );
+
+    expect(result.verdict).toBe('still_reproducible');
+    expect(result.confidence).toBe('high');
+  });
+
+  it('returns still_reproducible when an original network failure is present', () => {
+    const manifest = makeManifest({
+      oracles: { networkFailures: [{ urlPattern: '/api/orders', status: 500 }] },
+    });
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: [],
+        networkFailures: [{ url: 'https://example.com/api/orders', status: 500 }],
+        a11yRuleIds: [],
+      })
+    );
+
+    expect(result.verdict).toBe('still_reproducible');
+  });
+
+  it('returns new_related_issue when replay completes with a different failure', () => {
+    const manifest = makeManifest();
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: ['Different checkout error'],
+        networkFailures: [],
+        a11yRuleIds: [],
+      })
+    );
+
+    expect(result.verdict).toBe('new_related_issue');
+    expect(result.confidence).toBe('low');
+  });
+
+  it('does not mark partial oracle matches as fully reproducible', () => {
+    const manifest = makeManifest();
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: ['Cannot read properties of null at checkout.js:12'],
+        networkFailures: [],
+        a11yRuleIds: [],
+      })
+    );
+
+    expect(result.verdict).toBe('new_related_issue');
+    expect(result.confidence).toBe('medium');
+  });
+
+  it('returns changed_surface when visual drift exceeds the threshold', () => {
+    const manifest = makeManifest();
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: [],
+        networkFailures: [],
+        a11yRuleIds: [],
+        visualDiffRatio: 0.08,
+      })
+    );
+
+    expect(result.verdict).toBe('changed_surface');
+  });
+
+  it('returns new_related_issue when observed behavior is still broken without oracle failures', () => {
+    const manifest = makeManifest({ oracles: {} });
+    const result = evaluateReplayConfirmation(manifest, {
+      ...buildStaticReplayResult(manifest, {
+        consoleErrors: [],
+        networkFailures: [],
+        a11yRuleIds: [],
+      }),
+      observedNow: { expected: 'Order is submitted', actual: 'Checkout shows validation error' },
+    });
+
+    expect(result.verdict).toBe('new_related_issue');
+  });
+
+  it('returns cannot_confirm when replay stops on a blocked action', () => {
+    const manifest = makeManifest({
+      replay: {
+        actions: [
+          {
+            id: 'act-1',
+            kind: 'click',
+            summary: 'Click submit',
+            source: 'page',
+            status: 'blocked',
+            timestamp: '2026-05-20T18:00:01.000Z',
+          },
+        ],
+        breadcrumbs: ['checkout'],
+        objective: 'Submit checkout',
+        maxStepsBudget: 1,
+      },
+    });
+    const result = evaluateReplayConfirmation(
+      manifest,
+      buildStaticReplayResult(manifest, {
+        consoleErrors: [],
+        networkFailures: [],
+        a11yRuleIds: [],
+      })
+    );
+
+    expect(result.verdict).toBe('cannot_confirm');
+    expect(result.confidence).toBe('low');
+    expect(result.replay.stoppedReason).toBe('Click submit');
+  });
+});

--- a/src/repro/replayer.ts
+++ b/src/repro/replayer.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import type {
+  ConfirmationResult,
+  ConfirmationVerdict,
+  FindingConfidence,
+  ReplayableAction,
+} from '../types.js';
+import type { FindingReplayManifest } from './manifest.js';
+import { compareReplayOracles } from './oracles.js';
+
+export type ReplayStepStatus = 'worked' | 'blocked' | 'error' | 'unclear';
+
+export interface ReplayStepOutcome {
+  actionId: string;
+  status: ReplayStepStatus;
+  summary: string;
+}
+
+export interface CurrentOracleObservation {
+  consoleErrors: string[];
+  networkFailures: Array<{ url: string; status: number }>;
+  a11yRuleIds: string[];
+  visualDiffRatio?: number;
+}
+
+export interface ManifestReplayResult {
+  stepOutcomes: ReplayStepOutcome[];
+  observed: CurrentOracleObservation;
+  observedNow?: { expected?: string; actual?: string };
+  evidence?: { screenshotRef?: string; consoleErrors?: string[] };
+  durationMs: number;
+  stoppedReason?: string;
+}
+
+export interface ReplayAdapter {
+  replay(manifest: FindingReplayManifest): Promise<ManifestReplayResult>;
+}
+
+function actionOutcome(action: ReplayableAction): ReplayStepStatus {
+  switch (action.status) {
+    case 'worked':
+    case 'recorded':
+      return 'worked';
+    case 'blocked':
+      return 'blocked';
+    case 'error':
+      return 'error';
+    case 'unclear':
+      return 'unclear';
+  }
+}
+
+function countOriginalConsoleErrors(manifest: FindingReplayManifest): number {
+  return manifest.oracles.consoleErrorFragments?.length ?? 0;
+}
+
+function countOriginalNetworkFailures(manifest: FindingReplayManifest): number {
+  return manifest.oracles.networkFailures?.length ?? 0;
+}
+
+function countOriginalA11yViolations(manifest: FindingReplayManifest): number {
+  return manifest.oracles.a11yRuleIds?.length ?? 0;
+}
+
+function deriveConfidence(options: {
+  verdict: ConfirmationVerdict;
+  actionsRequested: number;
+  actionsCompleted: number;
+  oracleMatchRatio: number;
+}): FindingConfidence {
+  if (options.verdict === 'cannot_confirm') return 'low';
+  if (options.actionsRequested === 0) return 'low';
+  if (options.actionsCompleted < options.actionsRequested) return 'low';
+  if (options.verdict === 'new_related_issue' || options.verdict === 'changed_surface') {
+    return options.oracleMatchRatio > 0 ? 'medium' : 'low';
+  }
+  return options.oracleMatchRatio >= 1 ? 'high' : 'medium';
+}
+
+function deriveVerdict(options: {
+  blockingStep?: ReplayStepOutcome;
+  oracleSummary: ReturnType<typeof compareReplayOracles>;
+  visualDiffRatio?: number;
+  observedNow?: { expected?: string; actual?: string };
+}): ConfirmationVerdict {
+  if (options.blockingStep) return 'cannot_confirm';
+  if (options.visualDiffRatio !== undefined && options.visualDiffRatio > 0.05) {
+    return 'changed_surface';
+  }
+  if (options.oracleSummary.allOriginalMatched) return 'still_reproducible';
+  if (options.oracleSummary.hasCurrentFailures) return 'new_related_issue';
+  if (
+    options.observedNow?.actual &&
+    options.observedNow.expected &&
+    options.observedNow.actual !== options.observedNow.expected
+  ) {
+    return 'new_related_issue';
+  }
+  return 'fixed';
+}
+
+export function evaluateReplayConfirmation(
+  manifest: FindingReplayManifest,
+  replayResult: ManifestReplayResult
+): ConfirmationResult {
+  const blockingStep = replayResult.stepOutcomes.find(
+    (step) => step.status === 'blocked' || step.status === 'error'
+  );
+  const actionsRequested = manifest.replay.actions.length;
+  const actionsCompleted = replayResult.stepOutcomes.filter(
+    (step) => step.status === 'worked'
+  ).length;
+  const oracleSummary = compareReplayOracles(manifest, replayResult.observed);
+  const verdict = deriveVerdict({
+    blockingStep,
+    oracleSummary,
+    visualDiffRatio: replayResult.observed.visualDiffRatio,
+    observedNow: replayResult.observedNow,
+  });
+
+  return {
+    findingId: manifest.finding.id,
+    signature: manifest.finding.signature,
+    verdict,
+    confidence: deriveConfidence({
+      verdict,
+      actionsRequested,
+      actionsCompleted,
+      oracleMatchRatio: oracleSummary.matchRatio,
+    }),
+    origin: {
+      runStartedAt: manifest.origin.runStartedAt,
+      targetUrl: manifest.origin.targetUrl,
+    },
+    replay: {
+      actionsRequested,
+      actionsCompleted,
+      ...(blockingStep || replayResult.stoppedReason
+        ? { stoppedReason: blockingStep?.summary ?? replayResult.stoppedReason }
+        : {}),
+    },
+    oracleComparison: {
+      consoleErrorsOriginal: countOriginalConsoleErrors(manifest),
+      consoleErrorsCurrent: replayResult.observed.consoleErrors.length,
+      networkFailuresOriginal: countOriginalNetworkFailures(manifest),
+      networkFailuresCurrent: replayResult.observed.networkFailures.length,
+      a11yViolationsOriginal: countOriginalA11yViolations(manifest),
+      a11yViolationsCurrent: replayResult.observed.a11yRuleIds.length,
+      ...(replayResult.observed.visualDiffRatio !== undefined
+        ? { visualDiffRatio: replayResult.observed.visualDiffRatio }
+        : {}),
+    },
+    observedNow: replayResult.observedNow ?? {},
+    evidence: {
+      ...(replayResult.evidence?.screenshotRef
+        ? { screenshotRef: replayResult.evidence.screenshotRef }
+        : {}),
+      consoleErrors: replayResult.evidence?.consoleErrors ?? replayResult.observed.consoleErrors,
+    },
+    durationMs: replayResult.durationMs,
+  };
+}
+
+export function buildStaticReplayResult(
+  manifest: FindingReplayManifest,
+  observed: CurrentOracleObservation
+): ManifestReplayResult {
+  return {
+    stepOutcomes: manifest.replay.actions.map((action) => ({
+      actionId: action.id,
+      status: actionOutcome(action),
+      summary: action.summary,
+    })),
+    observed,
+    durationMs: 0,
+  };
+}
+
+function cannotConfirmResult(manifest: FindingReplayManifest, reason: string): ConfirmationResult {
+  return evaluateReplayConfirmation(manifest, {
+    stepOutcomes: [
+      {
+        actionId: manifest.replay.actions[0]?.id ?? 'replay-adapter',
+        status: 'blocked',
+        summary: reason,
+      },
+    ],
+    observed: { consoleErrors: [], networkFailures: [], a11yRuleIds: [] },
+    durationMs: 0,
+    stoppedReason: reason,
+  });
+}
+
+export async function confirmManifest(
+  manifest: FindingReplayManifest,
+  adapter?: ReplayAdapter
+): Promise<ConfirmationResult> {
+  if (!adapter) {
+    return cannotConfirmResult(
+      manifest,
+      'Live replay adapter is not configured in this first slice.'
+    );
+  }
+  return evaluateReplayConfirmation(manifest, await adapter.replay(manifest));
+}

--- a/src/repro/replayer.ts
+++ b/src/repro/replayer.ts
@@ -7,6 +7,7 @@ import type {
   FindingConfidence,
   ReplayableAction,
 } from '../types.js';
+import { VISUAL_CHANGED_SURFACE_RATIO_THRESHOLD } from '../constants.js';
 import type { FindingReplayManifest } from './manifest.js';
 import { compareReplayOracles } from './oracles.js';
 
@@ -86,7 +87,10 @@ function deriveVerdict(options: {
   observedNow?: { expected?: string; actual?: string };
 }): ConfirmationVerdict {
   if (options.blockingStep) return 'cannot_confirm';
-  if (options.visualDiffRatio !== undefined && options.visualDiffRatio > 0.05) {
+  if (
+    options.visualDiffRatio !== undefined &&
+    options.visualDiffRatio >= VISUAL_CHANGED_SURFACE_RATIO_THRESHOLD
+  ) {
     return 'changed_surface';
   }
   if (options.oracleSummary.allOriginalMatched) return 'still_reproducible';

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,39 @@ export interface RunResult {
   workflowComparison?: WorkflowAutomatonComparison;
 }
 
+export type ConfirmationVerdict =
+  | 'fixed'
+  | 'still_reproducible'
+  | 'cannot_confirm'
+  | 'changed_surface'
+  | 'new_related_issue';
+
+export interface ConfirmationResult {
+  findingId: string;
+  signature: string;
+  verdict: ConfirmationVerdict;
+  confidence: FindingConfidence;
+  origin: { runStartedAt: string; targetUrl: string };
+  replay: {
+    actionsRequested: number;
+    actionsCompleted: number;
+    stoppedReason?: string;
+  };
+  oracleComparison: {
+    consoleErrorsOriginal: number;
+    consoleErrorsCurrent: number;
+    networkFailuresOriginal: number;
+    networkFailuresCurrent: number;
+    a11yViolationsOriginal: number;
+    a11yViolationsCurrent: number;
+    visualDiffRatio?: number;
+  };
+  observedNow: { expected?: string; actual?: string };
+  evidence: { screenshotRef?: string; consoleErrors: string[] };
+  suggestedNextAction?: string;
+  durationMs: number;
+}
+
 export interface ExplorationLedger {
   version: 1;
   events: ExplorationLedgerEvent[];

--- a/src/yargs.d.ts
+++ b/src/yargs.d.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+declare module 'yargs' {
+  interface DramaturgeYargsParseResult {
+    _: unknown[];
+    config?: string;
+    resume?: string;
+    diff?: string;
+    dashboard?: boolean;
+    login?: boolean;
+    headless?: boolean;
+    provider?: string;
+    preset?: string;
+    focus?: string[];
+    format?: string;
+    profile?: string;
+    template?: string;
+    url?: string;
+    output?: string;
+    repo?: string;
+    noScan?: boolean;
+    suppressed?: boolean;
+    all?: boolean;
+    reason?: string;
+    save?: boolean;
+    fromReport?: string;
+    finding?: string;
+  }
+
+  interface DramaturgeYargsInstance {
+    exitProcess(enabled: boolean): DramaturgeYargsInstance;
+    help(enabled: boolean): DramaturgeYargsInstance;
+    version(enabled: boolean): DramaturgeYargsInstance;
+    strictOptions(): DramaturgeYargsInstance;
+    parserConfiguration(configuration: Record<string, unknown>): DramaturgeYargsInstance;
+    fail(handler: (message: string, error?: Error) => void): DramaturgeYargsInstance;
+    option(name: string, configuration: Record<string, unknown>): DramaturgeYargsInstance;
+    parseSync(): DramaturgeYargsParseResult;
+  }
+
+  export default function yargs(args: readonly string[]): DramaturgeYargsInstance;
+}


### PR DESCRIPTION
## Summary
- Add first-slice `dramaturge confirm` CLI plumbing and output formats.
- Emit per-finding replay manifests under `findings/<id>.json` during report generation.
- Add replay/oracle evaluation seams for fixed/still-reproducible/cannot-confirm plus guarded changed/new-related verdict handling.
- Thread config/profile context into the future live replay handoff.

## Verification
- `pnpm run test` — 138 files, 1270 tests passed
- `pnpm run build`
- `pnpm run lint` — passes with existing warnings
- Final subagent review: APPROVED

Refs #180