### PR TITLE
feat: enable confirm live replay

### DIFF
--- a/src/commands/confirm.test.ts
+++ b/src/commands/confirm.test.ts
@@ -211,6 +211,41 @@ describe('runConfirmCommand', () => {
     expect(loadConfig).toHaveBeenCalledWith('custom.json');
   });
 
+  it('attempts to load the default config when no --config path is provided', async () => {
+    const loadConfig = vi.fn().mockReturnValue({ targetUrl: 'https://example.com' });
+    h.deps.loadConfig = loadConfig;
+
+    const code = await runConfirmCommand(
+      {
+        finding: 'BUG-0001',
+        fromReport: h.reportDir,
+        format: 'short',
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(loadConfig).toHaveBeenCalledWith(undefined);
+  });
+
+  it('falls back to manifest-only replay when implicit default config loading fails', async () => {
+    h.deps.loadConfig = vi.fn().mockImplementation(() => {
+      throw new Error('Config file not found');
+    });
+
+    const code = await runConfirmCommand(
+      {
+        finding: 'BUG-0001',
+        fromReport: h.reportDir,
+        format: 'short',
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(h.logs.join('\n')).toContain('BUG-0001 fixed');
+  });
+
   it('passes loaded config and selected profile into replay context', async () => {
     const config = { targetUrl: 'https://example.com' } as DramaturgeConfig;
     const replayManifest = vi.fn().mockResolvedValue(makeResult('fixed'));

--- a/src/commands/confirm.test.ts
+++ b/src/commands/confirm.test.ts
@@ -2,12 +2,22 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runConfirmCommand, type ConfirmDependencies } from './confirm.js';
+import type { DramaturgeConfig } from '../config.js';
 import type { ConfirmationResult } from '../types.js';
 import type { FindingReplayManifest } from '../repro/manifest.js';
+import type { ManifestReplayResult, ReplayAdapter } from '../repro/replayer.js';
+
+const mocks = vi.hoisted(() => ({
+  createLiveReplayAdapter: vi.fn(),
+}));
+
+vi.mock('../repro/live-replay.js', () => ({
+  createLiveReplayAdapter: mocks.createLiveReplayAdapter,
+}));
 
 function makeManifest(): FindingReplayManifest {
   return {
@@ -43,7 +53,11 @@ function makeResult(verdict: ConfirmationResult['verdict']): ConfirmationResult 
     verdict,
     confidence: verdict === 'cannot_confirm' ? 'low' : 'high',
     origin: { runStartedAt: '2026-05-20T18:00:00.000Z', targetUrl: 'https://example.com' },
-    replay: { actionsRequested: 1, actionsCompleted: verdict === 'cannot_confirm' ? 0 : 1 },
+    replay: {
+      actionsRequested: 1,
+      actionsCompleted: verdict === 'cannot_confirm' ? 0 : 1,
+      ...(verdict === 'cannot_confirm' ? { stoppedReason: 'selector not found' } : {}),
+    },
     oracleComparison: {
       consoleErrorsOriginal: 1,
       consoleErrorsCurrent: verdict === 'still_reproducible' ? 1 : 0,
@@ -55,6 +69,14 @@ function makeResult(verdict: ConfirmationResult['verdict']): ConfirmationResult 
     observedNow: {},
     evidence: { consoleErrors: [] },
     durationMs: 0,
+  };
+}
+
+function makeReplayResult(): ManifestReplayResult {
+  return {
+    stepOutcomes: [],
+    observed: { consoleErrors: [], networkFailures: [], a11yRuleIds: [] },
+    durationMs: 1,
   };
 }
 
@@ -97,6 +119,9 @@ describe('runConfirmCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.createLiveReplayAdapter.mockReturnValue({
+      replay: vi.fn().mockResolvedValue(makeReplayResult()),
+    } satisfies ReplayAdapter);
     h = makeHarness();
   });
 
@@ -133,7 +158,23 @@ describe('runConfirmCommand', () => {
 
     expect(code).toBe(2);
     expect(h.logs.join('\n')).toContain('cannot_confirm');
+    expect(h.logs.join('\n')).toContain('selector not found');
   });
+
+  it.each(['changed_surface', 'new_related_issue'] as const)(
+    'returns 3 for %s',
+    async (verdict) => {
+      h = makeHarness(makeResult(verdict));
+
+      const code = await runConfirmCommand(
+        { finding: 'BUG-0001', fromReport: h.reportDir, format: 'short' },
+        h.deps
+      );
+
+      expect(code).toBe(3);
+      expect(h.logs.join('\n')).toContain('BUG-0001');
+    }
+  );
 
   it('loads the newest report with findings when --from-report is omitted', async () => {
     const reportsRoot = join(h.cwd, 'dramaturge-reports');
@@ -141,6 +182,10 @@ describe('runConfirmCommand', () => {
     const newer = join(reportsRoot, '2026-05-20T00-00-00');
     writeManifest(older);
     writeManifest(newer);
+    const oldTime = new Date('2026-05-19T00:00:00.000Z');
+    const newTime = new Date('2026-05-20T00:00:00.000Z');
+    utimesSync(older, oldTime, oldTime);
+    utimesSync(newer, newTime, newTime);
 
     const code = await runConfirmCommand({ finding: 'BUG-0001', format: 'short' }, h.deps);
 
@@ -167,7 +212,7 @@ describe('runConfirmCommand', () => {
   });
 
   it('passes loaded config and selected profile into replay context', async () => {
-    const config = { targetUrl: 'https://example.com' };
+    const config = { targetUrl: 'https://example.com' } as DramaturgeConfig;
     const replayManifest = vi.fn().mockResolvedValue(makeResult('fixed'));
     h.deps.loadConfig = vi.fn().mockReturnValue(config);
     h.deps.replayManifest = replayManifest;
@@ -188,6 +233,27 @@ describe('runConfirmCommand', () => {
       config,
       profile: 'admin',
     });
+  });
+
+  it('uses the live replay adapter by default', async () => {
+    h.deps.replayManifest = undefined;
+    const config = { targetUrl: 'https://example.com' } as DramaturgeConfig;
+    h.deps.loadConfig = vi.fn().mockReturnValue(config);
+
+    const code = await runConfirmCommand(
+      {
+        finding: 'BUG-0001',
+        fromReport: h.reportDir,
+        configPath: 'custom.json',
+        format: 'short',
+        profile: 'admin',
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(mocks.createLiveReplayAdapter).toHaveBeenCalledWith({ config, profile: 'admin' });
+    expect(h.logs.join('\n')).toContain('BUG-0001 fixed');
   });
 
   it('returns usage error when finding is missing', async () => {

--- a/src/commands/confirm.ts
+++ b/src/commands/confirm.ts
@@ -4,8 +4,10 @@
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import type { ConfirmationResult } from '../types.js';
+import type { DramaturgeConfig } from '../config.js';
 import { loadFindingReplayManifest, type FindingReplayManifest } from '../repro/manifest.js';
 import { confirmManifest } from '../repro/replayer.js';
+import { createLiveReplayAdapter } from '../repro/live-replay.js';
 
 export type ConfirmOutputFormat = 'markdown' | 'json' | 'short';
 
@@ -19,7 +21,7 @@ export interface ConfirmCommandArgs {
 
 export interface ConfirmReplayContext {
   manifest: FindingReplayManifest;
-  config?: unknown;
+  config?: DramaturgeConfig;
   profile?: string;
 }
 
@@ -27,7 +29,7 @@ export interface ConfirmDependencies {
   log: (message: string) => void;
   error: (message: string) => void;
   cwd: string;
-  loadConfig?: (configPath?: string) => unknown;
+  loadConfig?: (configPath?: string) => DramaturgeConfig;
   replayManifest?: (context: ConfirmReplayContext) => Promise<ConfirmationResult>;
 }
 
@@ -126,7 +128,7 @@ export async function runConfirmCommand(
     const manifest = loadFindingReplayManifest(reportDir, args.finding);
     const result = deps.replayManifest
       ? await deps.replayManifest({ manifest, config, profile: args.profile })
-      : await confirmManifest(manifest);
+      : await confirmManifest(manifest, createLiveReplayAdapter({ config, profile: args.profile }));
     deps.log(renderResult(result, args.format ?? 'markdown'));
     return resultExitCode(result);
   } catch (error) {

--- a/src/commands/confirm.ts
+++ b/src/commands/confirm.ts
@@ -33,6 +33,25 @@ export interface ConfirmDependencies {
   replayManifest?: (context: ConfirmReplayContext) => Promise<ConfirmationResult>;
 }
 
+function loadReplayConfig(
+  args: ConfirmCommandArgs,
+  deps: ConfirmDependencies
+): DramaturgeConfig | undefined {
+  if (!deps.loadConfig) {
+    return undefined;
+  }
+
+  if (args.configPath) {
+    return deps.loadConfig(args.configPath);
+  }
+
+  try {
+    return deps.loadConfig(undefined);
+  } catch {
+    return undefined;
+  }
+}
+
 function resultExitCode(result: ConfirmationResult): number {
   switch (result.verdict) {
     case 'fixed':
@@ -124,7 +143,7 @@ export async function runConfirmCommand(
 
   const reportDir = resolveReportDir(deps.cwd, args.fromReport);
   try {
-    const config = args.configPath ? deps.loadConfig?.(args.configPath) : undefined;
+    const config = loadReplayConfig(args, deps);
     const manifest = loadFindingReplayManifest(reportDir, args.finding);
     const result = deps.replayManifest
       ? await deps.replayManifest({ manifest, config, profile: args.profile })

--- a/src/repro/live-replay.test.ts
+++ b/src/repro/live-replay.test.ts
@@ -324,6 +324,24 @@ describe('createLiveReplayAdapter', () => {
     expect(harness.calls.fill).toEqual([]);
   });
 
+  it('closes the browser agent when initialization fails', async () => {
+    const harness = makeFakePage();
+    const initError = new Error('browser failed to start');
+
+    const adapter = createLiveReplayAdapter({
+      createBrowserAgent: () =>
+        makeFakeBrowserAgent(harness, {
+          init: async () => {
+            harness.calls.init += 1;
+            throw initError;
+          },
+        }),
+    });
+
+    await expect(adapter.replay(makeManifest())).rejects.toThrow('browser failed to start');
+    expect(harness.calls.close).toBe(1);
+  });
+
   it('captures network and page-error oracles during live replay', async () => {
     const harness = makeFakePage({
       pageErrorOnClick: 'checkout exploded',

--- a/src/repro/live-replay.test.ts
+++ b/src/repro/live-replay.test.ts
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Page } from 'playwright';
+import type { BrowserAgent } from '../browser/agent.js';
+import type { DramaturgeConfig } from '../config.js';
+import type { ReplayableAction } from '../types.js';
+import type { FindingReplayManifest } from './manifest.js';
+import { confirmManifest } from './replayer.js';
+import { createLiveReplayAdapter } from './live-replay.js';
+
+type PageEventName = 'console' | 'pageerror' | 'response' | 'requestfailed';
+type PageEventHandler = (value: unknown) => void;
+
+interface FakePageHarness {
+  page: Page;
+  calls: {
+    close: number;
+    click: string[];
+    fill: Array<{ selector: string; value: string }>;
+    goto: string[];
+    init: number;
+    keyPress: string[];
+    screenshot: number;
+  };
+}
+
+function makeAction(overrides: Partial<ReplayableAction> = {}): ReplayableAction {
+  return {
+    id: 'act-1',
+    kind: 'click',
+    summary: 'Click submit',
+    source: 'page',
+    status: 'recorded',
+    timestamp: '2026-05-20T18:00:01.000Z',
+    selector: 'button[type="submit"]',
+    ...overrides,
+  };
+}
+
+function makeManifest(overrides: Partial<FindingReplayManifest> = {}): FindingReplayManifest {
+  return {
+    schemaVersion: 1,
+    finding: {
+      id: 'BUG-0001',
+      signature: '["Bug","Major","Submit fails","ok","bad"]',
+      category: 'Bug',
+      severity: 'Major',
+      title: 'Submit fails',
+      expected: 'ok',
+      actual: 'bad',
+      evidenceTypes: ['console-error'],
+    },
+    origin: {
+      runStartedAt: '2026-05-20T18:00:00.000Z',
+      targetUrl: 'https://example.com/app',
+      route: '/checkout',
+    },
+    replay: {
+      actions: [makeAction()],
+      breadcrumbs: ['checkout'],
+      objective: 'Submit checkout',
+      maxStepsBudget: 1,
+    },
+    oracles: { consoleErrorFragments: ['Cannot read properties of null'] },
+    ...overrides,
+  };
+}
+
+function makeFakeBrowserAgent(
+  harness: FakePageHarness,
+  overrides: Partial<BrowserAgent> = {}
+): BrowserAgent {
+  return {
+    context: {
+      pages: () => [harness.page],
+    },
+    init: async () => {
+      harness.calls.init += 1;
+    },
+    agent: () => ({
+      execute: async () => ({ success: true }),
+    }),
+    close: async () => {
+      harness.calls.close += 1;
+    },
+    ...overrides,
+  };
+}
+
+function makeFakePage(
+  options: {
+    consoleOnClick?: string;
+    failClick?: boolean;
+    initialUrl?: string;
+    pageErrorOnClick?: string;
+    requestFailedOnClick?: string;
+    responseOnClick?: { url: string; status: number };
+    screenshotFails?: boolean;
+  } = {}
+): FakePageHarness {
+  let currentUrl = options.initialUrl ?? 'about:blank';
+  const handlers = new Map<PageEventName, PageEventHandler[]>();
+  const calls: FakePageHarness['calls'] = {
+    close: 0,
+    click: [],
+    fill: [],
+    goto: [],
+    init: 0,
+    keyPress: [],
+    screenshot: 0,
+  };
+  const emit = (eventName: PageEventName, value: unknown) => {
+    for (const handler of handlers.get(eventName) ?? []) {
+      handler(value);
+    }
+  };
+  const page = {
+    goto: async (url: string) => {
+      currentUrl = url;
+      calls.goto.push(url);
+    },
+    keyboard: {
+      press: async (key: string) => {
+        calls.keyPress.push(key);
+      },
+    },
+    locator: (selector: string) => ({
+      click: async () => {
+        calls.click.push(selector);
+        if (options.failClick) {
+          throw new Error('selector not found');
+        }
+        if (options.consoleOnClick) {
+          emit('console', {
+            type: () => 'error',
+            text: () => options.consoleOnClick,
+          });
+        }
+        if (options.pageErrorOnClick) {
+          emit('pageerror', new Error(options.pageErrorOnClick));
+        }
+        if (options.responseOnClick) {
+          emit('response', {
+            status: () => options.responseOnClick?.status ?? 200,
+            url: () => options.responseOnClick?.url ?? '',
+          });
+        }
+        if (options.requestFailedOnClick) {
+          emit('requestfailed', {
+            url: () => options.requestFailedOnClick,
+          });
+        }
+      },
+      fill: async (value: string) => {
+        calls.fill.push({ selector, value });
+      },
+      press: async (key: string) => {
+        calls.keyPress.push(`${selector}:${key}`);
+      },
+    }),
+    off: (eventName: PageEventName, handler: PageEventHandler) => {
+      handlers.set(
+        eventName,
+        (handlers.get(eventName) ?? []).filter((candidate) => candidate !== handler)
+      );
+    },
+    on: (eventName: PageEventName, handler: PageEventHandler) => {
+      handlers.set(eventName, [...(handlers.get(eventName) ?? []), handler]);
+    },
+    screenshot: async () => {
+      calls.screenshot += 1;
+      if (options.screenshotFails) {
+        throw new Error('screenshot failed');
+      }
+      return Buffer.from('png');
+    },
+    url: () => currentUrl,
+    waitForLoadState: async () => undefined,
+  };
+
+  return {
+    page: page as unknown as Page,
+    calls,
+  };
+}
+
+describe('createLiveReplayAdapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns fixed after replaying all actions when original oracles are not observed', async () => {
+    const harness = makeFakePage();
+    const manifest = makeManifest();
+    const result = await confirmManifest(
+      manifest,
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('fixed');
+    expect(result.replay).toMatchObject({ actionsRequested: 1, actionsCompleted: 1 });
+    expect(harness.calls.goto).toEqual(['https://example.com/checkout']);
+    expect(harness.calls.click).toEqual(['button[type="submit"]']);
+    expect(harness.calls.close).toBe(1);
+  });
+
+  it('replays navigation, input, keydown, screenshots, and discovery no-ops', async () => {
+    const harness = makeFakePage();
+    const manifest = makeManifest({
+      replay: {
+        actions: [
+          makeAction({
+            id: 'act-nav',
+            kind: 'navigate',
+            summary: 'Navigate to checkout step 2',
+            url: 'https://example.com/checkout?step=2',
+          }),
+          makeAction({
+            id: 'act-input',
+            kind: 'input',
+            summary: 'Fill email',
+            selector: 'input[name="email"]',
+            value: 'user@example.com',
+          }),
+          makeAction({
+            id: 'act-key',
+            kind: 'keydown',
+            summary: 'Press enter',
+            key: 'Enter',
+            selector: undefined,
+          }),
+          makeAction({ id: 'act-shot', kind: 'screenshot', summary: 'Capture state' }),
+          makeAction({ id: 'act-edge', kind: 'discover-edge', summary: 'Discover edge' }),
+        ],
+        breadcrumbs: ['checkout'],
+        objective: 'Submit checkout',
+        maxStepsBudget: 5,
+      },
+    });
+
+    const result = await confirmManifest(
+      manifest,
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('fixed');
+    expect(result.replay.actionsCompleted).toBe(5);
+    expect(harness.calls.goto).toEqual([
+      'https://example.com/checkout',
+      'https://example.com/checkout?step=2',
+    ]);
+    expect(harness.calls.fill).toEqual([
+      { selector: 'input[name="email"]', value: 'user@example.com' },
+    ]);
+    expect(harness.calls.keyPress).toEqual(['Enter']);
+    expect(harness.calls.screenshot).toBe(2);
+  });
+
+  it('returns still_reproducible when live replay observes the original console oracle', async () => {
+    const harness = makeFakePage({
+      consoleOnClick: 'Cannot read properties of null at checkout.js:12',
+    });
+    const manifest = makeManifest({
+      oracles: { consoleErrorFragments: ['Cannot read properties of null'] },
+    });
+    const result = await confirmManifest(
+      manifest,
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('still_reproducible');
+    expect(result.oracleComparison.consoleErrorsCurrent).toBe(1);
+  });
+
+  it('returns cannot_confirm when a recorded action cannot be replayed', async () => {
+    const harness = makeFakePage({ failClick: true });
+    const result = await confirmManifest(
+      makeManifest(),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('cannot_confirm');
+    expect(result.replay.actionsCompleted).toBe(0);
+    expect(result.replay.stoppedReason).toContain('selector not found');
+    expect(harness.calls.close).toBe(1);
+  });
+
+  it('returns cannot_confirm for redacted input values', async () => {
+    const harness = makeFakePage();
+    const result = await confirmManifest(
+      makeManifest({
+        replay: {
+          actions: [
+            makeAction({
+              kind: 'input',
+              selector: 'input[type="password"]',
+              summary: 'Fill password',
+              redacted: true,
+              value: undefined,
+            }),
+          ],
+          breadcrumbs: [],
+          objective: 'Submit login',
+          maxStepsBudget: 1,
+        },
+      }),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('cannot_confirm');
+    expect(result.replay.stoppedReason).toContain('redacted');
+    expect(harness.calls.fill).toEqual([]);
+  });
+
+  it('captures network and page-error oracles during live replay', async () => {
+    const harness = makeFakePage({
+      pageErrorOnClick: 'checkout exploded',
+      responseOnClick: { url: 'https://example.com/api/orders', status: 500 },
+    });
+    const result = await confirmManifest(
+      makeManifest({
+        oracles: {
+          consoleErrorFragments: ['checkout exploded'],
+          networkFailures: [{ urlPattern: '/api/orders', status: 500 }],
+        },
+      }),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('still_reproducible');
+    expect(result.oracleComparison.consoleErrorsCurrent).toBe(1);
+    expect(result.oracleComparison.networkFailuresCurrent).toBe(1);
+  });
+
+  it('returns new_related_issue for a different failure of the original oracle type', async () => {
+    const harness = makeFakePage({
+      consoleOnClick: 'Different checkout failure',
+    });
+    const result = await confirmManifest(
+      makeManifest({
+        oracles: { consoleErrorFragments: ['Cannot read properties of null'] },
+      }),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('new_related_issue');
+    expect(result.oracleComparison.consoleErrorsCurrent).toBe(1);
+  });
+
+  it('captures exact network oracle matches even below the configured noise threshold', async () => {
+    const harness = makeFakePage({
+      responseOnClick: { url: 'https://example.com/api/orders/42', status: 404 },
+    });
+    const config = {
+      targetUrl: 'https://example.com/app',
+      autoCapture: { networkErrorMinStatus: 500 },
+      browser: { headless: true },
+      models: { planner: 'anthropic/claude-sonnet-4-6' },
+    } as DramaturgeConfig;
+
+    const result = await confirmManifest(
+      makeManifest({
+        oracles: { networkFailures: [{ urlPattern: '/api/orders', status: 404 }] },
+      }),
+      createLiveReplayAdapter({
+        authenticateBrowser: vi.fn().mockResolvedValue(undefined),
+        config,
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('still_reproducible');
+    expect(result.oracleComparison.networkFailuresCurrent).toBe(1);
+  });
+
+  it('captures matching request-failure oracles', async () => {
+    const harness = makeFakePage({
+      requestFailedOnClick: 'https://example.com/api/orders',
+    });
+    const result = await confirmManifest(
+      makeManifest({
+        oracles: {
+          networkFailures: [{ urlPattern: '/api/orders', status: 0 }],
+        },
+      }),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('still_reproducible');
+    expect(result.oracleComparison.networkFailuresCurrent).toBe(1);
+  });
+
+  it('ignores unrelated runtime noise when original oracles are absent', async () => {
+    const harness = makeFakePage({
+      consoleOnClick: 'unrelated ad script error',
+      requestFailedOnClick: 'https://example.com/ad.js',
+      screenshotFails: true,
+    });
+    const result = await confirmManifest(
+      makeManifest({ oracles: {} }),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('fixed');
+    expect(result.oracleComparison.consoleErrorsCurrent).toBe(0);
+    expect(result.oracleComparison.networkFailuresCurrent).toBe(0);
+    expect(result.evidence.screenshotRef).toBeUndefined();
+  });
+
+  it('skips the initial navigation when the page is already at the replay target', async () => {
+    const harness = makeFakePage({ initialUrl: 'https://example.com/checkout' });
+    const result = await confirmManifest(
+      makeManifest(),
+      createLiveReplayAdapter({
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(result.verdict).toBe('fixed');
+    expect(harness.calls.goto).toEqual([]);
+  });
+
+  it('authenticates with config before replaying the manifest route', async () => {
+    const harness = makeFakePage();
+    const authenticateBrowser = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      targetUrl: 'https://preview.example.test/root',
+      autoCapture: { networkErrorMinStatus: 500 },
+      browser: { headless: true },
+      models: { planner: 'anthropic/claude-sonnet-4-6' },
+    } as DramaturgeConfig;
+
+    const result = await confirmManifest(
+      makeManifest({
+        origin: {
+          runStartedAt: '2026-05-20T18:00:00.000Z',
+          targetUrl: 'https://example.com/app',
+          route: '/checkout',
+          authProfile: 'customer',
+        },
+      }),
+      createLiveReplayAdapter({
+        authenticateBrowser,
+        config,
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+        profile: 'admin',
+      })
+    );
+
+    expect(result.verdict).toBe('fixed');
+    expect(authenticateBrowser).toHaveBeenCalledWith(expect.anything(), config, 'admin');
+    expect(harness.calls.goto).toEqual(['https://preview.example.test/checkout']);
+  });
+
+  it('falls back to the manifest auth profile when no profile override is provided', async () => {
+    const harness = makeFakePage();
+    const authenticateBrowser = vi.fn().mockResolvedValue(undefined);
+    const config = {
+      targetUrl: 'https://preview.example.test/root',
+      autoCapture: { networkErrorMinStatus: 500 },
+      browser: { headless: true },
+      models: { planner: 'anthropic/claude-sonnet-4-6' },
+    } as DramaturgeConfig;
+
+    await confirmManifest(
+      makeManifest({
+        origin: {
+          runStartedAt: '2026-05-20T18:00:00.000Z',
+          targetUrl: 'https://example.com/app',
+          route: '/checkout',
+          authProfile: 'customer',
+        },
+      }),
+      createLiveReplayAdapter({
+        authenticateBrowser,
+        config,
+        createBrowserAgent: () => makeFakeBrowserAgent(harness),
+      })
+    );
+
+    expect(authenticateBrowser).toHaveBeenCalledWith(expect.anything(), config, 'customer');
+  });
+});

--- a/src/repro/live-replay.ts
+++ b/src/repro/live-replay.ts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import type { ConsoleMessage, Page, Request, Response } from 'playwright';
+import type { BrowserAgent } from '../browser/agent.js';
+import { createStagehandAgent, StagehandBrowserAgent } from '../browser/stagehand-agent.js';
+import { authenticate } from '../auth/authenticator.js';
+import type { DramaturgeConfig } from '../config.js';
+import type { ReplayableAction } from '../types.js';
+import type { FindingReplayManifest } from './manifest.js';
+import type { CurrentOracleObservation, ManifestReplayResult, ReplayAdapter } from './replayer.js';
+
+export interface LiveReplayOptions {
+  config?: DramaturgeConfig;
+  profile?: string;
+  createBrowserAgent?: () => BrowserAgent;
+  authenticateBrowser?: (
+    agent: BrowserAgent,
+    config: DramaturgeConfig,
+    profile?: string
+  ) => Promise<void>;
+}
+
+function replayTargetUrl(manifest: FindingReplayManifest, config?: DramaturgeConfig): string {
+  const baseUrl = config?.targetUrl ?? manifest.origin.targetUrl;
+  if (!manifest.origin.route) return baseUrl;
+  return new URL(manifest.origin.route, baseUrl).href;
+}
+
+function actionTarget(action: ReplayableAction): string | undefined {
+  return action.selector ?? action.url;
+}
+
+function blockedStep(
+  action: ReplayableAction,
+  summary: string
+): ManifestReplayResult['stepOutcomes'][number] {
+  return {
+    actionId: action.id,
+    status: 'blocked',
+    summary,
+  };
+}
+
+async function settlePage(page: Page): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout: 2_000 }).catch(() => undefined);
+}
+
+async function replayAction(page: Page, action: ReplayableAction): Promise<void> {
+  switch (action.kind) {
+    case 'navigate':
+      await page.goto(action.url ?? page.url(), { waitUntil: 'domcontentloaded' });
+      return;
+    case 'click':
+    case 'submit':
+    case 'open':
+    case 'close':
+    case 'toggle':
+      if (!action.selector) throw new Error(`${action.kind} action is missing a selector`);
+      await page.locator(action.selector).click();
+      return;
+    case 'input':
+      if (!action.selector) throw new Error('input action is missing a selector');
+      if (action.redacted || action.value === undefined) {
+        throw new Error('input action value was redacted and cannot be replayed');
+      }
+      await page.locator(action.selector).fill(action.value);
+      return;
+    case 'keydown':
+      if (!action.key) throw new Error('keydown action is missing a key');
+      if (action.selector) {
+        await page.locator(action.selector).press(action.key);
+        return;
+      }
+      await page.keyboard.press(action.key);
+      return;
+    case 'screenshot':
+      await page.screenshot({ fullPage: true });
+      return;
+    case 'discover-edge':
+      return;
+  }
+}
+
+function attachOracleCollectors(
+  manifest: FindingReplayManifest,
+  page: Page,
+  networkErrorMinStatus = 400
+): { observed: CurrentOracleObservation; detach: () => void } {
+  const observed: CurrentOracleObservation = {
+    consoleErrors: [],
+    networkFailures: [],
+    a11yRuleIds: [],
+  };
+
+  const consoleFragments = manifest.oracles.consoleErrorFragments ?? [];
+  const networkFailures = manifest.oracles.networkFailures ?? [];
+  const matchesConsoleOracle = (text: string) =>
+    consoleFragments.some((fragment) => text.includes(fragment));
+  const matchesNetworkOracle = (url: string, status: number) =>
+    networkFailures.some(
+      (failure) => status === failure.status && url.includes(failure.urlPattern)
+    );
+
+  const onConsole = (message: ConsoleMessage) => {
+    const text = message.text();
+    if (message.type() === 'error' && (matchesConsoleOracle(text) || consoleFragments.length > 0)) {
+      observed.consoleErrors.push(text);
+    }
+  };
+  const onPageError = (error: Error) => {
+    if (matchesConsoleOracle(error.message) || consoleFragments.length > 0) {
+      observed.consoleErrors.push(error.message);
+    }
+  };
+  const onResponse = (response: Response) => {
+    const status = response.status();
+    const url = response.url();
+    if (
+      matchesNetworkOracle(url, status) ||
+      (status >= networkErrorMinStatus && networkFailures.length > 0)
+    ) {
+      observed.networkFailures.push({ url: response.url(), status });
+    }
+  };
+  const onRequestFailed = (request: Request) => {
+    if (matchesNetworkOracle(request.url(), 0) || networkFailures.length > 0) {
+      observed.networkFailures.push({ url: request.url(), status: 0 });
+    }
+  };
+
+  page.on('console', onConsole);
+  page.on('pageerror', onPageError);
+  page.on('response', onResponse);
+  page.on('requestfailed', onRequestFailed);
+
+  return {
+    observed,
+    detach: () => {
+      page.off('console', onConsole);
+      page.off('pageerror', onPageError);
+      page.off('response', onResponse);
+      page.off('requestfailed', onRequestFailed);
+    },
+  };
+}
+
+function firstPage(agent: BrowserAgent): Page {
+  const page = agent.context.pages()[0];
+  if (!page) {
+    throw new Error('Live replay could not start because no browser page was available.');
+  }
+  return page;
+}
+
+async function defaultAuthenticateBrowser(
+  agent: BrowserAgent,
+  config: DramaturgeConfig,
+  profile?: string
+): Promise<void> {
+  if (!(agent instanceof StagehandBrowserAgent)) {
+    throw new Error('Configured auth requires a Stagehand browser agent.');
+  }
+  await authenticate(agent.getStagehand(), config, profile);
+}
+
+export function createLiveReplayAdapter(options: LiveReplayOptions = {}): ReplayAdapter {
+  return {
+    replay: async (manifest) => {
+      const startedAt = Date.now();
+      const agent = options.createBrowserAgent?.() ?? createStagehandAgent();
+      await agent.init({
+        headless: options.config?.browser.headless ?? true,
+        modelName: options.config?.models.browserOps ?? options.config?.models.planner,
+        verbose: 0,
+      });
+
+      try {
+        if (options.config) {
+          await (options.authenticateBrowser ?? defaultAuthenticateBrowser)(
+            agent,
+            options.config,
+            options.profile ?? manifest.origin.authProfile
+          );
+        }
+
+        const page = firstPage(agent);
+        const targetUrl = replayTargetUrl(manifest, options.config);
+        const { observed, detach } = attachOracleCollectors(
+          manifest,
+          page,
+          options.config?.autoCapture.networkErrorMinStatus
+        );
+        const stepOutcomes: ManifestReplayResult['stepOutcomes'] = [];
+        try {
+          if (page.url() !== targetUrl) {
+            await page.goto(targetUrl, { waitUntil: 'domcontentloaded' });
+          }
+
+          for (const action of manifest.replay.actions) {
+            try {
+              await replayAction(page, action);
+              await settlePage(page);
+              stepOutcomes.push({
+                actionId: action.id,
+                status: 'worked',
+                summary: `${action.summary} (replayed)`,
+              });
+            } catch (error) {
+              const reason = error instanceof Error ? error.message : String(error);
+              stepOutcomes.push(
+                blockedStep(action, `${actionTarget(action) ?? action.kind}: ${reason}`)
+              );
+              break;
+            }
+          }
+        } finally {
+          detach();
+        }
+
+        const screenshot = await page.screenshot({ fullPage: true }).catch(() => undefined);
+        return {
+          stepOutcomes,
+          observed,
+          evidence: {
+            consoleErrors: observed.consoleErrors,
+            ...(screenshot ? { screenshotRef: `inline:${screenshot.length} bytes` } : {}),
+          },
+          durationMs: Date.now() - startedAt,
+          ...(stepOutcomes.some((step) => step.status === 'blocked')
+            ? { stoppedReason: stepOutcomes.find((step) => step.status === 'blocked')?.summary }
+            : {}),
+        };
+      } finally {
+        await agent.close();
+      }
+    },
+  };
+}

--- a/src/repro/live-replay.ts
+++ b/src/repro/live-replay.ts
@@ -169,13 +169,13 @@ export function createLiveReplayAdapter(options: LiveReplayOptions = {}): Replay
     replay: async (manifest) => {
       const startedAt = Date.now();
       const agent = options.createBrowserAgent?.() ?? createStagehandAgent();
-      await agent.init({
-        headless: options.config?.browser.headless ?? true,
-        modelName: options.config?.models.browserOps ?? options.config?.models.planner,
-        verbose: 0,
-      });
-
       try {
+        await agent.init({
+          headless: options.config?.browser.headless ?? true,
+          modelName: options.config?.models.browserOps ?? options.config?.models.planner,
+          verbose: 0,
+        });
+
         if (options.config) {
           await (options.authenticateBrowser ?? defaultAuthenticateBrowser)(
             agent,


### PR DESCRIPTION
## Summary
- Add a live replay adapter for `dramaturge confirm` that executes replay manifests against a browser through the existing `ReplayAdapter` seam.
- Wire the confirm command to use live replay by default while preserving dependency injection for deterministic tests.
- Capture original-oracle matches and same-type related failures without letting unrelated page noise fail fixed confirmations.
- Cover action replay, auth/profile routing, oracle capture, exact network matches below noise thresholds, and confirm exit-code rendering.

## Verification
- `pnpm exec vitest run src/commands/confirm.test.ts src/repro/replayer.test.ts src/repro/live-replay.test.ts --coverage.enabled=false` — 32 tests passed
- `pnpm run test` — 139 files, 1287 tests passed
- `pnpm run build`
- `pnpm run lint` — passes with existing warnings
- `pnpm exec prettier --check src/commands/confirm.ts src/commands/confirm.test.ts src/repro/live-replay.ts src/repro/live-replay.test.ts`
- `git diff --check`
- Review agent: APPROVED

Refs #180