### PR TITLE
feat: add regression promotion dry-run foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,28 @@ means at least one still reproduces, `2` means confirmation infrastructure could
 verdict, and `3` means a changed surface or related new issue needs human review. Older report
 directories without `findings/<id>.json` manifests fail with a clear re-run message.
 
+## Building a Regression Suite
+
+Dramaturge can score findings for promotion into durable Playwright regression specs. The first
+workflow slice is intentionally review-first: list promotable findings, then dry-run the generated
+spec before writing anything into your repo.
+
+```bash
+# Show quality scores for findings in the latest report
+npx dramaturge regress list
+
+# Use a specific report directory
+npx dramaturge regress list --from-report ./dramaturge-reports/2026-05-20T18-46-40
+
+# Preview the Playwright spec for a promotable finding
+npx dramaturge regress promote BUG-0042 --dry-run
+```
+
+Quality scores consider URL context, replay actions, expected/actual detail, screenshots,
+console/network evidence, accessibility evidence, and confidence. Findings must have replay actions
+and differing expected/actual behavior before they are promotable. Non-dry-run promotion is reserved
+for the next slice, so this command never writes tests into your repo yet.
+
 ## What It Does
 
 Dramaturge uses AI-powered browser agents to test your web application automatically. It:

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -306,6 +306,24 @@ describe('parseCliArgs', () => {
     );
   });
 
+  it('parses regress promote dry-run arguments', () => {
+    const result = parseCliArgs([
+      'regress',
+      'promote',
+      'BUG-0042',
+      '--dry-run',
+      '--from-report',
+      './reports/run-1',
+    ]);
+    expect(result).toMatchObject({
+      command: 'regress',
+      regressSubcommand: 'promote',
+      regressPositional: ['BUG-0042'],
+      regressDryRun: true,
+      regressFromReport: './reports/run-1',
+    });
+  });
+
   it('parses --profile flag', () => {
     const result = parseCliArgs(['run', 'https://example.com', '--profile', 'admin']);
     expect(result.profile).toBe('admin');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { runInit, type InitTemplate } from './commands/init.js';
 import { runTriageCommand } from './commands/triage.js';
 import { runBenchmarkCommand as runBenchmarkCommandImpl } from './commands/benchmark.js';
 import { runConfirmCommand, type ConfirmOutputFormat } from './commands/confirm.js';
+import { runRegressCommand } from './commands/regress.js';
 import type {
   ErrorEvent,
   FindingEvent,
@@ -45,6 +46,7 @@ export interface ParsedCliArgs {
     | 'memory'
     | 'benchmark'
     | 'confirm'
+    | 'regress'
     | 'help';
   configPath?: string;
   resumeDir?: string;
@@ -105,6 +107,16 @@ export interface ParsedCliArgs {
   confirmFromReport?: string;
   /** --format flag for confirm command */
   confirmFormat?: ConfirmOutputFormat;
+  /** Subcommand after regress (e.g. "list", "promote") */
+  regressSubcommand?: string;
+  /** Positional args for regress subcommands */
+  regressPositional?: string[];
+  /** --from-report flag for regress command */
+  regressFromReport?: string;
+  /** --dry-run flag for regress promote */
+  regressDryRun?: boolean;
+  /** --output flag for regress promote */
+  regressOutput?: string;
 }
 
 export interface CliDependencies {
@@ -130,6 +142,7 @@ Commands:
   memory stats         Show memory store statistics
   benchmark [app-id]   Run signal-to-noise benchmarks against well-known apps
   confirm              Confirm whether a previous finding still reproduces
+  regress <sub>        Manage durable regression specs (list | promote)
 
 Run options:
   --config <path>      Path to config file (default: dramaturge.config.json)
@@ -181,6 +194,11 @@ Confirm options:
   --from-report <dir>  Report directory containing findings/<id>.json
   --format <format>    Output format: markdown, json, or short
 
+Regress options:
+  --from-report <dir>  Report directory containing report.json
+  --dry-run            regress promote: print the generated spec without writing
+  --output <dir>       regress promote: output directory for future non-dry-run writes
+
 Examples:
   dramaturge run https://my-app.example.com           # Quick run, no config needed
   dramaturge run https://my-app.example.com --login    # Run with interactive auth
@@ -200,6 +218,8 @@ Examples:
   dramaturge baselines approve --all                   # Recapture all visual baselines
   dramaturge memory stats                              # Summarize memory store
   dramaturge confirm --finding BUG-0042 --from-report ./dramaturge-reports/latest
+  dramaturge regress list --from-report ./dramaturge-reports/latest
+  dramaturge regress promote BUG-0042 --dry-run
 
 Environment variables:
   ANTHROPIC_API_KEY              API key for Anthropic models
@@ -238,6 +258,7 @@ const KNOWN_COMMANDS = new Set([
   'memory',
   'benchmark',
   'confirm',
+  'regress',
 ]);
 const TRIAGE_COMMANDS = new Set(['findings', 'baselines', 'memory']);
 const VALID_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'azure', 'openrouter', 'github']);
@@ -324,6 +345,16 @@ function parseFocusModes(values: readonly string[] | undefined): FocusMode[] | u
   return focusModes;
 }
 
+function parseSubcommandPositionals(
+  positionals: readonly string[],
+  index: number
+): { subcommand?: string; positional?: string[] } {
+  return {
+    subcommand: positionals[index],
+    positional: positionals.length > index + 1 ? [...positionals.slice(index + 1)] : undefined,
+  };
+}
+
 function parsePositionals(
   positionals: readonly string[],
   parsedUrl?: string
@@ -334,6 +365,8 @@ function parsePositionals(
   triageSubcommand?: string;
   triagePositional?: string[];
   benchmarkAppId?: string;
+  regressSubcommand?: string;
+  regressPositional?: string[];
 } {
   const [firstPositional] = positionals;
   const hasExplicitCommand = !!firstPositional && KNOWN_COMMANDS.has(firstPositional);
@@ -356,9 +389,8 @@ function parsePositionals(
   }
 
   if (TRIAGE_COMMANDS.has(command)) {
-    const triageSubcommand = positionals[index];
-    const triagePositional =
-      positionals.length > index + 1 ? [...positionals.slice(index + 1)] : undefined;
+    const { subcommand: triageSubcommand, positional: triagePositional } =
+      parseSubcommandPositionals(positionals, index);
     return { command, url, triageSubcommand, triagePositional };
   }
 
@@ -369,6 +401,12 @@ function parsePositionals(
       throw new Error(`Unknown argument: ${positionals[index]}`);
     }
     return { command, url, benchmarkAppId };
+  }
+
+  if (command === 'regress') {
+    const { subcommand: regressSubcommand, positional: regressPositional } =
+      parseSubcommandPositionals(positionals, index);
+    return { command, url, regressSubcommand, regressPositional };
   }
 
   if (positionals[index]) {
@@ -411,6 +449,7 @@ function parseWithYargs(args: readonly string[]) {
     .option('no-scan', { type: 'boolean' })
     .option('suppressed', { type: 'boolean' })
     .option('all', { type: 'boolean' })
+    .option('dry-run', { type: 'boolean' })
     .option('reason', { type: 'string' })
     .option('save', { type: 'boolean' })
     .parseSync();
@@ -535,6 +574,15 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
           confirmFormat,
         }
       : {}),
+    ...(positionalArgs.command === 'regress'
+      ? {
+          regressSubcommand: positionalArgs.regressSubcommand,
+          regressPositional: positionalArgs.regressPositional,
+          regressFromReport: argv.fromReport,
+          regressDryRun: argv.dryRun ?? undefined,
+          regressOutput: argv.output,
+        }
+      : {}),
   };
 }
 
@@ -626,6 +674,18 @@ export async function runCli(
             cwd: process.cwd(),
             loadConfig: dependencies.loadConfig,
           }
+        );
+
+      case 'regress':
+        return runRegressCommand(
+          {
+            subcommand: parsedArgs.regressSubcommand,
+            positional: parsedArgs.regressPositional ?? [],
+            fromReport: parsedArgs.regressFromReport,
+            dryRun: parsedArgs.regressDryRun,
+            output: parsedArgs.regressOutput,
+          },
+          { log: dependencies.log, error: dependencies.error, cwd: process.cwd() }
         );
 
       default:

--- a/src/commands/regress.test.ts
+++ b/src/commands/regress.test.ts
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runRegressCommand, type RegressDependencies } from './regress.js';
+import { renderJson } from '../report/json.js';
+import type { AreaResult, RawFinding, ReplayableAction, RunResult } from '../types.js';
+
+interface Harness {
+  cwd: string;
+  reportDir: string;
+  logs: string[];
+  errors: string[];
+  deps: RegressDependencies;
+}
+
+function makeAction(overrides: Partial<ReplayableAction> = {}): ReplayableAction {
+  return {
+    id: 'act-nav',
+    kind: 'navigate',
+    url: 'https://example.com/checkout',
+    summary: 'navigate to checkout',
+    source: 'page',
+    status: 'worked',
+    timestamp: '2026-05-20T18:01:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeFinding(overrides: Partial<RawFinding> = {}): RawFinding {
+  return {
+    ref: 'fid-create-dialog',
+    category: 'Bug',
+    severity: 'Major',
+    title: 'Create dialog never opens',
+    stepsToReproduce: ['Open checkout', 'Click Create'],
+    expected: 'The create dialog opens',
+    actual: 'Nothing happens',
+    screenshotRef: 'bug.png',
+    evidenceIds: ['ev-console'],
+    meta: {
+      source: 'agent',
+      confidence: 'high',
+      repro: {
+        objective: 'Validate create dialog flow',
+        route: 'https://example.com/checkout',
+        breadcrumbs: ['Open checkout', 'Click Create'],
+        actionIds: ['act-nav', 'act-click'],
+        evidenceIds: ['ev-console'],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeArea(overrides: Partial<AreaResult> = {}): AreaResult {
+  return {
+    name: 'Checkout',
+    url: 'https://example.com/checkout',
+    steps: 2,
+    findings: [makeFinding()],
+    replayableActions: [
+      makeAction(),
+      makeAction({
+        id: 'act-click',
+        kind: 'click',
+        selector: "button[data-testid='create']",
+        summary: 'click create',
+        timestamp: '2026-05-20T18:01:01.000Z',
+      }),
+    ],
+    screenshots: new Map(),
+    evidence: [
+      {
+        id: 'ev-console',
+        type: 'console-error',
+        summary: 'Cannot read properties of null',
+        timestamp: '2026-05-20T18:01:02.000Z',
+        areaName: 'Checkout',
+        relatedFindingIds: ['fid-create-dialog'],
+      },
+    ],
+    coverage: { controlsDiscovered: 1, controlsExercised: 1, events: [] },
+    pageType: 'form',
+    status: 'explored',
+    ...overrides,
+  };
+}
+
+function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  return {
+    targetUrl: 'https://example.com',
+    startTime: new Date('2026-05-20T18:00:00.000Z'),
+    endTime: new Date('2026-05-20T18:10:00.000Z'),
+    areaResults: [makeArea()],
+    unexploredAreas: [],
+    partial: false,
+    blindSpots: [],
+    ...overrides,
+  };
+}
+
+function writeReport(reportDir: string, runResult: RunResult = makeRunResult()): void {
+  mkdirSync(reportDir, { recursive: true });
+  writeFileSync(join(reportDir, 'report.json'), renderJson(runResult));
+}
+
+function makeHarness(runResult?: RunResult): Harness {
+  const cwd = mkdtempSync(join(tmpdir(), 'dramaturge-regress-'));
+  const reportDir = join(cwd, 'dramaturge-reports', 'run-1');
+  writeReport(reportDir, runResult);
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    cwd,
+    reportDir,
+    logs,
+    errors,
+    deps: {
+      cwd,
+      log: (message) => logs.push(message),
+      error: (message) => errors.push(message),
+    },
+  };
+}
+
+describe('runRegressCommand', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness();
+  });
+
+  afterEach(() => {
+    rmSync(h.cwd, { recursive: true, force: true });
+  });
+
+  it('lists findings with quality scores and promotable status from report.json', () => {
+    const code = runRegressCommand(
+      { subcommand: 'list', positional: [], fromReport: h.reportDir },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    const output = h.logs.join('\n');
+    expect(output).toContain('BUG-001');
+    expect(output).toContain('85/100');
+    expect(output).toContain('yes');
+  });
+
+  it('prints a generated Playwright spec for promotable findings in dry-run mode', () => {
+    const code = runRegressCommand(
+      {
+        subcommand: 'promote',
+        positional: ['BUG-001'],
+        fromReport: h.reportDir,
+        dryRun: true,
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    const output = h.logs.join('\n');
+    expect(output).toContain('// filename: bug-001-create-dialog-never-opens.spec.ts');
+    expect(output).toContain('import { test, expect } from "@playwright/test";');
+    expect(output).toContain('await page.goto("https://example.com/checkout");');
+    expect(output).toContain('button[data-testid');
+  });
+
+  it('uses exploration ledger actions when report action rows are unavailable', () => {
+    rmSync(h.cwd, { recursive: true, force: true });
+    const click = makeAction({
+      id: 'act-click',
+      kind: 'click',
+      selector: "button[data-testid='create']",
+      summary: 'click create from ledger',
+      timestamp: '2026-05-20T18:01:01.000Z',
+    });
+    h = makeHarness(
+      makeRunResult({
+        areaResults: [
+          makeArea({
+            replayableActions: [],
+          }),
+        ],
+        explorationLedger: {
+          version: 1,
+          events: [
+            {
+              id: 'ledger-action-1',
+              kind: 'action',
+              actionId: click.id,
+              action: click,
+              timestamp: click.timestamp,
+              areaName: 'Checkout',
+              source: 'action-recorder',
+            },
+          ],
+        },
+      })
+    );
+
+    const code = runRegressCommand(
+      {
+        subcommand: 'promote',
+        positional: ['BUG-001'],
+        fromReport: h.reportDir,
+        dryRun: true,
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(h.logs.join('\n')).toContain('click();');
+  });
+
+  it('uses normalized finding-id evidence links for dry-run assertion inference', () => {
+    const code = runRegressCommand(
+      {
+        subcommand: 'promote',
+        positional: ['BUG-001'],
+        fromReport: h.reportDir,
+        dryRun: true,
+      },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    const output = h.logs.join('\n');
+    expect(output).toContain('const consoleErrors: string[] = [];');
+    expect(output).toContain(
+      'expect(consoleErrors, "No console errors expected").toHaveLength(0);'
+    );
+  });
+
+  it('refuses non-dry-run promotion in the first slice', () => {
+    const code = runRegressCommand(
+      { subcommand: 'promote', positional: ['BUG-001'], fromReport: h.reportDir },
+      h.deps
+    );
+
+    expect(code).toBe(1);
+    expect(h.errors.join('\n')).toContain('Only --dry-run promotion is supported');
+  });
+
+  it('refuses to promote low-quality findings', () => {
+    rmSync(h.cwd, { recursive: true, force: true });
+    h = makeHarness(
+      makeRunResult({
+        areaResults: [
+          makeArea({
+            name: 'Settings',
+            url: 'https://example.com/settings',
+            findings: [
+              makeFinding({
+                ref: 'fid-settings',
+                category: 'UX Concern',
+                severity: 'Minor',
+                title: 'Save feedback is unclear',
+                evidenceIds: [],
+                screenshotRef: undefined,
+                meta: {
+                  source: 'agent',
+                  confidence: 'low',
+                  repro: {
+                    objective: 'Inspect save feedback',
+                    route: 'https://example.com/settings',
+                    breadcrumbs: ['Open settings'],
+                    evidenceIds: [],
+                  },
+                },
+              }),
+            ],
+            replayableActions: [],
+            evidence: [],
+          }),
+        ],
+      })
+    );
+
+    const code = runRegressCommand(
+      {
+        subcommand: 'promote',
+        positional: ['UX-001'],
+        fromReport: h.reportDir,
+        dryRun: true,
+      },
+      h.deps
+    );
+
+    expect(code).toBe(1);
+    expect(h.errors.join('\n')).toContain('not promotable');
+  });
+
+  it('reports a missing report clearly', () => {
+    const code = runRegressCommand(
+      { subcommand: 'list', positional: [], fromReport: join(h.cwd, 'missing') },
+      h.deps
+    );
+
+    expect(code).toBe(1);
+    expect(h.errors.join('\n')).toContain('No report.json found');
+  });
+});

--- a/src/commands/regress.ts
+++ b/src/commands/regress.ts
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { scoreFindingQuality } from '../judge/quality-score.js';
+import { buildTestFileContent } from '../report/test-gen.js';
+import type {
+  AreaResult,
+  Evidence,
+  ExplorationLedger,
+  Finding,
+  ReplayableAction,
+  RunResult,
+} from '../types.js';
+
+export interface RegressDependencies {
+  log: (message: string) => void;
+  error: (message: string) => void;
+  cwd: string;
+}
+
+export interface RegressCommandArgs {
+  subcommand?: string;
+  positional: string[];
+  fromReport?: string;
+  dryRun?: boolean;
+  output?: string;
+}
+
+interface SerializedReportFinding {
+  id: string;
+  category: Finding['category'];
+  severity: Finding['severity'];
+  area: string;
+  title: string;
+  stepsToReproduce: string[];
+  expected: string;
+  actual: string;
+  screenshot?: string | null;
+  evidenceIds?: string[];
+  meta?: Finding['meta'] | null;
+  occurrenceCount?: number;
+  impactedAreas?: string[];
+  occurrences?: Finding['occurrences'];
+}
+
+interface SerializedReport {
+  meta?: { targetUrl?: string; startTime?: string; endTime?: string; partial?: boolean };
+  findings?: SerializedReportFinding[];
+  actions?: Array<ReplayableAction & { areaName?: string; route?: string | null }>;
+  evidence?: Evidence[];
+  coverage?: Array<{ name: string; url?: string | null }>;
+  explorationLedger?: ExplorationLedger | null;
+}
+
+interface GeneratedTestPreview {
+  finding: Finding;
+  generated: ReturnType<typeof buildTestFileContent>;
+}
+
+function resolveReportDir(cwd: string, fromReport?: string): string {
+  if (fromReport) return resolve(cwd, fromReport);
+
+  const reportsRoot = resolve(cwd, './dramaturge-reports');
+  if (!existsSync(reportsRoot)) return join(reportsRoot, 'latest');
+
+  const reportDirectories = readdirSync(reportsRoot)
+    .map((name) => {
+      const path = join(reportsRoot, name);
+      return { path, stats: statSync(path) };
+    })
+    .filter((entry) => entry.stats.isDirectory() && existsSync(join(entry.path, 'report.json')))
+    .sort((a, b) => b.stats.mtimeMs - a.stats.mtimeMs);
+  return reportDirectories[0]?.path ?? join(reportsRoot, 'latest');
+}
+
+function readReport(reportDir: string): SerializedReport {
+  const path = join(reportDir, 'report.json');
+  if (!existsSync(path)) {
+    throw new Error(`No report.json found in ${reportDir}. Run Dramaturge first.`);
+  }
+  return JSON.parse(readFileSync(path, 'utf-8')) as SerializedReport;
+}
+
+function areaUrl(report: SerializedReport, areaName: string): string | undefined {
+  return report.coverage?.find((area) => area.name === areaName)?.url ?? undefined;
+}
+
+function deserializeRunResult(report: SerializedReport): RunResult {
+  const evidence = report.evidence ?? [];
+  const actions = report.actions ?? [];
+  const findings = report.findings ?? [];
+  const areaNames = Array.from(
+    new Set([
+      ...(report.coverage?.map((area) => area.name) ?? []),
+      ...findings.map((finding) => finding.area),
+      ...actions.map((action) => action.areaName).filter((name): name is string => Boolean(name)),
+    ])
+  );
+  const areaResults: AreaResult[] = areaNames.map((name) => ({
+    name,
+    url: areaUrl(report, name),
+    steps: 0,
+    findings: findings
+      .filter((finding) => finding.area === name)
+      .map((finding) => ({
+        ref: finding.id,
+        category: finding.category,
+        severity: finding.severity,
+        title: finding.title,
+        stepsToReproduce: finding.stepsToReproduce,
+        expected: finding.expected,
+        actual: finding.actual,
+        ...(finding.screenshot ? { screenshotRef: finding.screenshot } : {}),
+        evidenceIds: finding.evidenceIds ?? [],
+        ...(finding.meta ? { meta: finding.meta } : {}),
+      })),
+    replayableActions: actions.filter((action) => action.areaName === name),
+    screenshots: new Map(),
+    evidence: evidence.filter((item) => item.areaName === name || !item.areaName),
+    coverage: { controlsDiscovered: 0, controlsExercised: 0, events: [] },
+    pageType: 'unknown',
+    status: 'explored',
+  }));
+
+  return {
+    targetUrl: report.meta?.targetUrl ?? '',
+    startTime: new Date(report.meta?.startTime ?? 0),
+    endTime: new Date(report.meta?.endTime ?? report.meta?.startTime ?? 0),
+    areaResults,
+    unexploredAreas: [],
+    partial: report.meta?.partial ?? false,
+    blindSpots: [],
+  };
+}
+
+function collectReportFindings(report: SerializedReport): Finding[] {
+  return (report.findings ?? []).map((finding) => ({
+    ...finding,
+    screenshot: finding.screenshot ?? undefined,
+    meta: finding.meta ?? undefined,
+    occurrenceCount: finding.occurrenceCount ?? finding.occurrences?.length ?? 1,
+    impactedAreas: finding.impactedAreas ?? [finding.area],
+    occurrences: finding.occurrences ?? [
+      {
+        area: finding.area,
+        route: finding.meta?.repro?.route,
+        evidenceIds: finding.evidenceIds ?? [],
+        ref: finding.id,
+      },
+    ],
+  }));
+}
+
+function findReportFinding(report: SerializedReport, findingId: string): Finding | undefined {
+  return collectReportFindings(report).find((finding) => finding.id === findingId);
+}
+
+function allEvidence(report: SerializedReport): Evidence[] {
+  return report.evidence ?? [];
+}
+
+function collectLedgerActions(report: SerializedReport): ReplayableAction[] {
+  return (
+    report.explorationLedger?.events.flatMap((event) =>
+      event.kind === 'action' ? [event.action] : []
+    ) ?? []
+  );
+}
+
+function renderList(report: SerializedReport): string {
+  const findings = collectReportFindings(report);
+  if (findings.length === 0) {
+    return 'No findings in report.';
+  }
+
+  const evidence = allEvidence(report);
+  const lines = [
+    'ID'.padEnd(12) +
+      'SEVERITY'.padEnd(10) +
+      'QUALITY'.padEnd(10) +
+      'PROMOTABLE'.padEnd(12) +
+      'TITLE',
+  ];
+  for (const finding of findings) {
+    const quality = scoreFindingQuality({ finding, evidence });
+    lines.push(
+      finding.id.padEnd(12) +
+        finding.severity.padEnd(10) +
+        `${quality.total}/100`.padEnd(10) +
+        (quality.promotable ? 'yes' : 'no').padEnd(12) +
+        finding.title
+    );
+  }
+  return lines.join('\n');
+}
+
+function findGeneratedTest(
+  report: SerializedReport,
+  findingId: string
+): GeneratedTestPreview | undefined {
+  const finding = findReportFinding(report, findingId);
+  if (!finding) {
+    return undefined;
+  }
+
+  const runResult = deserializeRunResult(report);
+  const areaActions = new Map(
+    runResult.areaResults.map((area) => [area.name, area.replayableActions ?? []] as const)
+  );
+  const generated = buildTestFileContent(finding, {
+    result: runResult,
+    areaActions,
+    ledgerActions: collectLedgerActions(report),
+  });
+  return { finding, generated };
+}
+
+function promoteFinding(
+  args: RegressCommandArgs,
+  report: SerializedReport,
+  deps: RegressDependencies
+): number {
+  const findingId = args.positional[0];
+  if (!findingId) {
+    deps.error('Usage: dramaturge regress promote <finding-id> --dry-run');
+    return 1;
+  }
+  if (!args.dryRun) {
+    deps.error('Only --dry-run promotion is supported in this first slice.');
+    return 1;
+  }
+
+  const match = findGeneratedTest(report, findingId);
+  if (!match) {
+    deps.error(`No finding found for ${findingId}.`);
+    return 1;
+  }
+
+  const evidence = allEvidence(report);
+  const quality = scoreFindingQuality({ finding: match.finding, evidence });
+  if (!quality.promotable) {
+    deps.error(`Finding ${findingId} is not promotable (quality ${quality.total}/100).`);
+    return 1;
+  }
+
+  deps.log(`// filename: ${match.generated.filename}`);
+  deps.log(match.generated.content);
+  return 0;
+}
+
+export function runRegressCommand(args: RegressCommandArgs, deps: RegressDependencies): number {
+  const reportDir = resolveReportDir(deps.cwd, args.fromReport);
+  try {
+    const report = readReport(reportDir);
+    switch (args.subcommand) {
+      case 'list':
+      case undefined:
+        deps.log(renderList(report));
+        return 0;
+      case 'promote':
+        return promoteFinding(args, report, deps);
+      default:
+        deps.error(`Unknown regress subcommand: ${args.subcommand}`);
+        return 1;
+    }
+  } catch (error) {
+    deps.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}

--- a/src/commands/regress.ts
+++ b/src/commands/regress.ts
@@ -95,9 +95,12 @@ function deserializeRunResult(report: SerializedReport): RunResult {
   const evidenceByArea = new Map<string, Evidence[]>();
   for (const item of evidence) {
     if (item.areaName) {
-      const perAreaEvidence = evidenceByArea.get(item.areaName) ?? [];
+      let perAreaEvidence = evidenceByArea.get(item.areaName);
+      if (!perAreaEvidence) {
+        perAreaEvidence = [];
+        evidenceByArea.set(item.areaName, perAreaEvidence);
+      }
       perAreaEvidence.push(item);
-      evidenceByArea.set(item.areaName, perAreaEvidence);
       continue;
     }
     globalEvidence.push(item);

--- a/src/commands/regress.ts
+++ b/src/commands/regress.ts
@@ -91,6 +91,17 @@ function deserializeRunResult(report: SerializedReport): RunResult {
   const evidence = report.evidence ?? [];
   const actions = report.actions ?? [];
   const findings = report.findings ?? [];
+  const globalEvidence: Evidence[] = [];
+  const evidenceByArea = new Map<string, Evidence[]>();
+  for (const item of evidence) {
+    if (item.areaName) {
+      const perAreaEvidence = evidenceByArea.get(item.areaName) ?? [];
+      perAreaEvidence.push(item);
+      evidenceByArea.set(item.areaName, perAreaEvidence);
+      continue;
+    }
+    globalEvidence.push(item);
+  }
   const areaNames = Array.from(
     new Set([
       ...(report.coverage?.map((area) => area.name) ?? []),
@@ -98,31 +109,34 @@ function deserializeRunResult(report: SerializedReport): RunResult {
       ...actions.map((action) => action.areaName).filter((name): name is string => Boolean(name)),
     ])
   );
-  const areaResults: AreaResult[] = areaNames.map((name) => ({
-    name,
-    url: areaUrl(report, name),
-    steps: 0,
-    findings: findings
-      .filter((finding) => finding.area === name)
-      .map((finding) => ({
-        ref: finding.id,
-        category: finding.category,
-        severity: finding.severity,
-        title: finding.title,
-        stepsToReproduce: finding.stepsToReproduce,
-        expected: finding.expected,
-        actual: finding.actual,
-        ...(finding.screenshot ? { screenshotRef: finding.screenshot } : {}),
-        evidenceIds: finding.evidenceIds ?? [],
-        ...(finding.meta ? { meta: finding.meta } : {}),
-      })),
-    replayableActions: actions.filter((action) => action.areaName === name),
-    screenshots: new Map(),
-    evidence: evidence.filter((item) => item.areaName === name || !item.areaName),
-    coverage: { controlsDiscovered: 0, controlsExercised: 0, events: [] },
-    pageType: 'unknown',
-    status: 'explored',
-  }));
+  const areaResults: AreaResult[] = areaNames.map((name) => {
+    const areaEvidence = evidenceByArea.get(name) ?? [];
+    return {
+      name,
+      url: areaUrl(report, name),
+      steps: 0,
+      findings: findings
+        .filter((finding) => finding.area === name)
+        .map((finding) => ({
+          ref: finding.id,
+          category: finding.category,
+          severity: finding.severity,
+          title: finding.title,
+          stepsToReproduce: finding.stepsToReproduce,
+          expected: finding.expected,
+          actual: finding.actual,
+          ...(finding.screenshot ? { screenshotRef: finding.screenshot } : {}),
+          evidenceIds: finding.evidenceIds ?? [],
+          ...(finding.meta ? { meta: finding.meta } : {}),
+        })),
+      replayableActions: actions.filter((action) => action.areaName === name),
+      screenshots: new Map(),
+      evidence: areaEvidence.length > 0 ? [...areaEvidence, ...globalEvidence] : globalEvidence,
+      coverage: { controlsDiscovered: 0, controlsExercised: 0, events: [] },
+      pageType: 'unknown',
+      status: 'explored',
+    };
+  });
 
   return {
     targetUrl: report.meta?.targetUrl ?? '',

--- a/src/judge/quality-score.test.ts
+++ b/src/judge/quality-score.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { describe, expect, it } from 'vitest';
+import { scoreFindingQuality } from './quality-score.js';
+import type { Evidence, Finding } from '../types.js';
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    id: 'BUG-0001',
+    ref: 'finding-1',
+    category: 'Bug',
+    severity: 'Major',
+    area: 'Checkout',
+    title: 'Submit fails',
+    stepsToReproduce: ['Open checkout', 'Submit form'],
+    expected: 'Order should submit',
+    actual: 'Submit throws',
+    screenshot: 'screenshots/bug.png',
+    evidenceIds: ['ev-console'],
+    occurrenceCount: 1,
+    impactedAreas: ['Checkout'],
+    occurrences: [
+      {
+        area: 'Checkout',
+        route: 'https://example.com/checkout',
+        evidenceIds: ['ev-console'],
+        ref: 'finding-1',
+      },
+    ],
+    meta: {
+      source: 'agent',
+      confidence: 'high',
+      repro: {
+        route: 'https://example.com/checkout',
+        objective: 'Reproduce submit failure',
+        breadcrumbs: ['Open checkout'],
+        actionIds: ['act-1'],
+        evidenceIds: ['ev-console'],
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeEvidence(overrides: Partial<Evidence> = {}): Evidence {
+  return {
+    id: 'ev-console',
+    type: 'console-error',
+    summary: 'Cannot read properties of null',
+    timestamp: '2026-05-20T18:00:00.000Z',
+    relatedFindingIds: ['finding-1'],
+    ...overrides,
+  };
+}
+
+describe('scoreFindingQuality', () => {
+  it('scores a strong replayable finding as promotable', () => {
+    const score = scoreFindingQuality({
+      finding: makeFinding(),
+      evidence: [makeEvidence()],
+      confirmationVerdict: 'fixed',
+    });
+
+    expect(score.total).toBe(95);
+    expect(score.promotable).toBe(true);
+    expect(score.components).toMatchObject({
+      hasUrl: true,
+      hasReproActions: true,
+      hasExpectedActual: true,
+      hasScreenshot: true,
+      hasNetworkOrConsole: true,
+      confidence: 'high',
+      confirmationVerdict: 'fixed',
+    });
+  });
+
+  it('requires replay actions before a finding is promotable', () => {
+    const finding = makeFinding({
+      meta: {
+        source: 'agent',
+        confidence: 'high',
+        repro: {
+          objective: 'Investigate',
+          breadcrumbs: [],
+          evidenceIds: ['ev-console'],
+        },
+      },
+    });
+
+    const score = scoreFindingQuality({ finding, evidence: [makeEvidence()] });
+
+    expect(score.components.hasReproActions).toBe(false);
+    expect(score.total).toBe(60);
+    expect(score.promotable).toBe(false);
+  });
+
+  it('requires expected and actual to differ before a finding is promotable', () => {
+    const finding = makeFinding({ actual: 'Order should submit' });
+
+    const score = scoreFindingQuality({ finding, evidence: [makeEvidence()] });
+
+    expect(score.components.hasExpectedActual).toBe(false);
+    expect(score.promotable).toBe(false);
+  });
+
+  it('counts accessibility evidence separately from console and network evidence', () => {
+    const score = scoreFindingQuality({
+      finding: makeFinding({ evidenceIds: ['ev-a11y'], screenshot: undefined }),
+      evidence: [makeEvidence({ id: 'ev-a11y', type: 'accessibility-scan' })],
+    });
+
+    expect(score.components.hasA11ySource).toBe(true);
+    expect(score.components.hasNetworkOrConsole).toBe(false);
+    expect(score.components.hasScreenshot).toBe(false);
+  });
+
+  it('does not count unrelated evidence when a finding has no evidence links', () => {
+    const finding = makeFinding({
+      evidenceIds: [],
+      meta: {
+        source: 'agent',
+        confidence: 'high',
+        repro: {
+          route: 'https://example.com/checkout',
+          objective: 'Reproduce submit failure',
+          breadcrumbs: [],
+          actionIds: ['act-1'],
+          evidenceIds: [],
+        },
+      },
+      occurrences: [
+        {
+          area: 'Checkout',
+          route: 'https://example.com/checkout',
+          evidenceIds: [],
+          ref: 'finding-1',
+        },
+      ],
+      screenshot: undefined,
+    });
+
+    const score = scoreFindingQuality({
+      finding,
+      evidence: [makeEvidence({ id: 'ev-other', relatedFindingIds: ['other-finding'] })],
+    });
+
+    expect(score.components.hasNetworkOrConsole).toBe(false);
+    expect(score.components.hasScreenshot).toBe(false);
+  });
+
+  it('counts evidence related by finding id or ref', () => {
+    const finding = makeFinding({ evidenceIds: [], screenshot: undefined });
+
+    const byId = scoreFindingQuality({
+      finding,
+      evidence: [makeEvidence({ id: 'ev-id', relatedFindingIds: ['BUG-0001'] })],
+    });
+    const byRef = scoreFindingQuality({
+      finding,
+      evidence: [makeEvidence({ id: 'ev-ref', relatedFindingIds: ['finding-1'] })],
+    });
+
+    expect(byId.components.hasNetworkOrConsole).toBe(true);
+    expect(byRef.components.hasNetworkOrConsole).toBe(true);
+  });
+
+  it('counts repro route as a URL source when occurrences do not have routes', () => {
+    const finding = makeFinding({
+      occurrences: [{ area: 'Checkout', evidenceIds: ['ev-console'], ref: 'finding-1' }],
+    });
+
+    const score = scoreFindingQuality({ finding, evidence: [makeEvidence()] });
+
+    expect(score.components.hasUrl).toBe(true);
+  });
+});

--- a/src/judge/quality-score.ts
+++ b/src/judge/quality-score.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import type { ConfirmationVerdict, Evidence, Finding, FindingConfidence } from '../types.js';
+
+export interface FindingQualityScore {
+  total: number;
+  components: {
+    hasUrl: boolean;
+    hasReproActions: boolean;
+    hasExpectedActual: boolean;
+    hasScreenshot: boolean;
+    hasNetworkOrConsole: boolean;
+    hasA11ySource: boolean;
+    confidence: FindingConfidence;
+    confirmationVerdict?: Extract<
+      ConfirmationVerdict,
+      'fixed' | 'still_reproducible' | 'cannot_confirm'
+    >;
+  };
+  promotable: boolean;
+}
+
+export interface ScoreFindingQualityOptions {
+  finding: Pick<
+    Finding,
+    | 'actual'
+    | 'evidenceIds'
+    | 'expected'
+    | 'id'
+    | 'meta'
+    | 'occurrences'
+    | 'ref'
+    | 'screenshot'
+    | 'screenshotRef'
+  >;
+  evidence?: Evidence[];
+  confirmationVerdict?: FindingQualityScore['components']['confirmationVerdict'];
+  threshold?: number;
+}
+
+const DEFAULT_PROMOTABLE_THRESHOLD = 60;
+
+function confidencePoints(confidence: FindingConfidence): number {
+  switch (confidence) {
+    case 'high':
+      return 15;
+    case 'medium':
+      return 10;
+    case 'low':
+      return 0;
+  }
+}
+
+function hasText(value: string | undefined): boolean {
+  return (value ?? '').trim().length > 0;
+}
+
+function hasExpectedActual(finding: ScoreFindingQualityOptions['finding']): boolean {
+  return (
+    hasText(finding.expected) && hasText(finding.actual) && finding.expected !== finding.actual
+  );
+}
+
+function linkedEvidence(
+  finding: ScoreFindingQualityOptions['finding'],
+  evidence: Evidence[]
+): Evidence[] {
+  const linkedEvidenceIds = new Set([
+    ...(finding.evidenceIds ?? []),
+    ...(finding.meta?.repro?.evidenceIds ?? []),
+    ...finding.occurrences.flatMap((occurrence) => occurrence.evidenceIds),
+  ]);
+
+  return evidence.filter(
+    (item) =>
+      linkedEvidenceIds.has(item.id) ||
+      item.relatedFindingIds.includes(finding.id) ||
+      (finding.ref != null && item.relatedFindingIds.includes(finding.ref))
+  );
+}
+
+function buildQualityComponents(
+  finding: ScoreFindingQualityOptions['finding'],
+  evidence: Evidence[],
+  confirmationVerdict: ScoreFindingQualityOptions['confirmationVerdict']
+): FindingQualityScore['components'] {
+  const hasScreenshotEvidence = evidence.some(
+    (item) => item.type === 'screenshot' || item.type === 'visual-diff'
+  );
+  const hasNetworkOrConsole = evidence.some(
+    (item) => item.type === 'network-error' || item.type === 'console-error'
+  );
+  const components: FindingQualityScore['components'] = {
+    hasUrl:
+      finding.occurrences.some((occurrence) => hasText(occurrence.route)) ||
+      hasText(finding.meta?.repro?.route),
+    hasReproActions: (finding.meta?.repro?.actionIds?.length ?? 0) > 0,
+    hasExpectedActual: hasExpectedActual(finding),
+    hasScreenshot:
+      hasText(finding.screenshot) || hasText(finding.screenshotRef) || hasScreenshotEvidence,
+    hasNetworkOrConsole,
+    hasA11ySource: evidence.some((item) => item.type === 'accessibility-scan'),
+    confidence: finding.meta?.confidence ?? 'low',
+  };
+
+  if (confirmationVerdict) {
+    components.confirmationVerdict = confirmationVerdict;
+  }
+
+  return components;
+}
+
+function totalQualityPoints(components: FindingQualityScore['components']): number {
+  return (
+    (components.hasUrl ? 10 : 0) +
+    (components.hasReproActions ? 25 : 0) +
+    (components.hasExpectedActual ? 15 : 0) +
+    (components.hasScreenshot ? 10 : 0) +
+    (components.hasNetworkOrConsole ? 10 : 0) +
+    (components.hasA11ySource ? 5 : 0) +
+    confidencePoints(components.confidence) +
+    (components.confirmationVerdict === 'fixed' ? 10 : 0)
+  );
+}
+
+export function scoreFindingQuality(options: ScoreFindingQualityOptions): FindingQualityScore {
+  const { finding, confirmationVerdict, threshold = DEFAULT_PROMOTABLE_THRESHOLD } = options;
+  const evidence = linkedEvidence(finding, options.evidence ?? []);
+  const components = buildQualityComponents(finding, evidence, confirmationVerdict);
+  const total = totalQualityPoints(components);
+
+  return {
+    total,
+    components,
+    promotable: total >= threshold && components.hasReproActions && components.hasExpectedActual,
+  };
+}

--- a/src/report/test-gen.ts
+++ b/src/report/test-gen.ts
@@ -17,6 +17,9 @@ export interface GeneratedPlaywrightTest {
   content: string;
 }
 
+type CollectedFinding = ReturnType<typeof collectFindings>[number];
+type InferredAssertion = ReturnType<typeof inferAssertions>[number];
+
 function slugify(value: string): string {
   return value
     .toLowerCase()
@@ -65,26 +68,37 @@ function isLedgerActionEvent(event: ExplorationLedgerEvent): event is Exploratio
   return event.kind === 'action';
 }
 
+function selectActionsById(
+  actions: ReplayableAction[],
+  actionIds: ReadonlySet<string>
+): ReplayableAction[] {
+  if (actionIds.size === 0) {
+    return actions;
+  }
+
+  return actions.filter((action) => actionIds.has(action.id));
+}
+
+function sanitizeCommentText(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ');
+}
+
 interface TestFileContext {
   result: RunResult;
   areaActions: Map<string, ReplayableAction[]>;
   ledgerActions: ReplayableAction[];
 }
 
-function buildTestFileContent(
-  finding: ReturnType<typeof collectFindings>[number],
+export function buildTestFileContent(
+  finding: CollectedFinding,
   ctx: TestFileContext
 ): GeneratedPlaywrightTest {
   const { result, areaActions, ledgerActions } = ctx;
   const area = result.areaResults.find((candidate) => candidate.name === finding.area);
   const availableActions = areaActions.get(finding.area) ?? [];
   const actionIds = new Set(finding.meta?.repro?.actionIds ?? []);
-  const selectedActions =
-    actionIds.size > 0
-      ? availableActions.filter((action) => actionIds.has(action.id))
-      : availableActions;
-  const selectedLedgerActions =
-    actionIds.size > 0 ? ledgerActions.filter((action) => actionIds.has(action.id)) : ledgerActions;
+  const selectedActions = selectActionsById(availableActions, actionIds);
+  const selectedLedgerActions = selectActionsById(ledgerActions, actionIds);
   const actionsToRender = selectedActions.length > 0 ? selectedActions : selectedLedgerActions;
   const renderedActions = actionsToRender
     .map((action) => renderAction(action))
@@ -105,6 +119,7 @@ function buildTestFileContent(
         .filter(
           (e) =>
             findingEvidenceIds.has(e.id) ||
+            e.relatedFindingIds.includes(finding.id) ||
             (finding.ref != null && e.relatedFindingIds.includes(finding.ref))
         )
         .map((e) => e.type)
@@ -119,7 +134,9 @@ function buildTestFileContent(
     evidenceTypes,
   });
 
-  const preambles = assertions.filter((a) => a.preamble).map((a) => a.preamble as string);
+  const preambles = assertions.flatMap((assertion) =>
+    assertion.preamble ? [assertion.preamble] : []
+  );
   const lines = buildTestBodyLines({
     finding,
     route,
@@ -132,12 +149,12 @@ function buildTestFileContent(
 }
 
 interface TestBodyOptions {
-  finding: ReturnType<typeof collectFindings>[number];
+  finding: CollectedFinding;
   route: string;
   preambles: string[];
   renderedActions: string[];
   breadcrumbs: string[];
-  assertions: ReturnType<typeof inferAssertions>;
+  assertions: InferredAssertion[];
 }
 
 function buildTestBodyLines(opts: TestBodyOptions): string[] {
@@ -146,8 +163,8 @@ function buildTestBodyLines(opts: TestBodyOptions): string[] {
     'import { test, expect } from "@playwright/test";',
     '',
     `test(${escapeString(`${finding.id}: ${finding.title}`)}, async ({ page }) => {`,
-    `  // Expected: ${finding.expected.replace(/[\r\n]+/g, ' ')}`,
-    `  // Actual: ${finding.actual.replace(/[\r\n]+/g, ' ')}`,
+    `  // Expected: ${sanitizeCommentText(finding.expected)}`,
+    `  // Actual: ${sanitizeCommentText(finding.actual)}`,
   ];
   for (const preamble of preambles) {
     lines.push(`  ${preamble}`);
@@ -160,7 +177,7 @@ function buildTestBodyLines(opts: TestBodyOptions): string[] {
   } else if (breadcrumbs.length > 0) {
     lines.push('  // Breadcrumbs:');
     for (const breadcrumb of breadcrumbs) {
-      lines.push(`  // - ${breadcrumb.replace(/[\r\n]+/g, ' ')}`);
+      lines.push(`  // - ${sanitizeCommentText(breadcrumb)}`);
     }
   }
   if (assertions.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,9 +3,11 @@
 
 import type { CrossRunClassification } from './report/cross-run-classification.js';
 import type { CostRecord } from './coverage/cost-tracker.js';
+import type { FindingQualityScore } from './judge/quality-score.js';
 import type { ObservedApiEndpoint } from './network/traffic-observer.js';
 import type { WorkflowAutomaton, WorkflowAutomatonComparison } from './workflow-automata/types.js';
 export type { CrossRunClassification };
+export type { FindingQualityScore };
 
 export type FindingCategory =
   | 'Bug'

--- a/src/yargs.d.ts
+++ b/src/yargs.d.ts
@@ -27,6 +27,7 @@ declare module 'yargs' {
     fromReport?: string;
     finding?: string;
     severity?: string;
+    dryRun?: boolean;
   }
 
   interface DramaturgeYargsInstance {


### PR DESCRIPTION
## Summary
- Add `FindingQualityScore` with tests for URL/replay/evidence/confidence-based promotability.
- Add `dramaturge regress list` and `dramaturge regress promote <id> --dry-run` as the first non-writing regression-suite promotion slice.
- Reuse generated Playwright test rendering for dry-run specs, including ledger-action fallback and normalized finding-id evidence links.
- Document the review-first regression suite workflow in README.

## Review loop
- Chunk 1 quality-score review: CHANGES REQUESTED, fixed evidence-linking and repro-route scoring, re-review APPROVED.
- Chunk 2 regress CLI review: CHANGES REQUESTED, fixed ledger-action deserialization and report.json round-trip coverage, re-review APPROVED.
- Deslop pass completed on changed files.
- Final architect review: CHANGES REQUESTED, fixed list/promote model parity and README wording, re-review APPROVED.

## Verification
- `pnpm exec vitest run src/judge/quality-score.test.ts src/commands/regress.test.ts src/cli.test.ts src/report/test-gen.test.ts src/report/json.test.ts src/repro/repro.test.ts --coverage.enabled=false`
- `pnpm exec prettier --check README.md src/cli.ts src/cli.test.ts src/commands/regress.ts src/commands/regress.test.ts src/judge/quality-score.ts src/judge/quality-score.test.ts src/report/test-gen.ts src/types.ts src/yargs.d.ts`
- `git diff --check`
- `pnpm run build`
- `pnpm run lint` (0 errors; existing warnings remain)
- `pnpm run test` (141 files, 1309 tests passed)

Refs #181