### PR TITLE
feat: make regression promotion write specs safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ directories without `findings/<id>.json` manifests fail with a clear re-run mess
 
 ## Building a Regression Suite
 
-Dramaturge can score findings for promotion into durable Playwright regression specs. The first
-workflow slice is intentionally review-first: list promotable findings, then dry-run the generated
-spec before writing anything into your repo.
+Dramaturge can score findings for promotion into durable Playwright regression specs. Review
+promotable findings first, dry-run the generated spec when you want to inspect it, then write the
+spec into your regression-test directory.
 
 ```bash
 # Show quality scores for findings in the latest report
@@ -78,12 +78,19 @@ npx dramaturge regress list --from-report ./dramaturge-reports/2026-05-20T18-46-
 
 # Preview the Playwright spec for a promotable finding
 npx dramaturge regress promote BUG-0042 --dry-run
+
+# Write the spec to ./tests/dramaturge (the default output directory)
+npx dramaturge regress promote BUG-0042
+
+# Or choose an explicit output directory
+npx dramaturge regress promote BUG-0042 --output tests/dramaturge/
 ```
 
 Quality scores consider URL context, replay actions, expected/actual detail, screenshots,
 console/network evidence, accessibility evidence, and confidence. Findings must have replay actions
-and differing expected/actual behavior before they are promotable. Non-dry-run promotion is reserved
-for the next slice, so this command never writes tests into your repo yet.
+and differing expected/actual behavior before they are promotable. Promoted specs use stable
+`<finding-id>__<title-slug>.spec.ts` filenames, include Dramaturge provenance headers, and refuse to
+overwrite existing files unless you pass `--force`.
 
 ## What It Does
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -312,15 +312,20 @@ describe('parseCliArgs', () => {
       'promote',
       'BUG-0042',
       '--dry-run',
+      '--force',
       '--from-report',
       './reports/run-1',
+      '--output',
+      './tests/dramaturge',
     ]);
     expect(result).toMatchObject({
       command: 'regress',
       regressSubcommand: 'promote',
       regressPositional: ['BUG-0042'],
       regressDryRun: true,
+      regressForce: true,
       regressFromReport: './reports/run-1',
+      regressOutput: './tests/dramaturge',
     });
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,6 +117,8 @@ export interface ParsedCliArgs {
   regressDryRun?: boolean;
   /** --output flag for regress promote */
   regressOutput?: string;
+  /** --force flag for regress promote overwrite */
+  regressForce?: boolean;
 }
 
 export interface CliDependencies {
@@ -197,7 +199,8 @@ Confirm options:
 Regress options:
   --from-report <dir>  Report directory containing report.json
   --dry-run            regress promote: print the generated spec without writing
-  --output <dir>       regress promote: output directory for future non-dry-run writes
+  --output <dir>       regress promote: output directory (default: ./tests/dramaturge)
+  --force              regress promote: overwrite an existing promoted spec
 
 Examples:
   dramaturge run https://my-app.example.com           # Quick run, no config needed
@@ -220,6 +223,7 @@ Examples:
   dramaturge confirm --finding BUG-0042 --from-report ./dramaturge-reports/latest
   dramaturge regress list --from-report ./dramaturge-reports/latest
   dramaturge regress promote BUG-0042 --dry-run
+  dramaturge regress promote BUG-0042 --output tests/dramaturge
 
 Environment variables:
   ANTHROPIC_API_KEY              API key for Anthropic models
@@ -450,6 +454,7 @@ function parseWithYargs(args: readonly string[]) {
     .option('suppressed', { type: 'boolean' })
     .option('all', { type: 'boolean' })
     .option('dry-run', { type: 'boolean' })
+    .option('force', { type: 'boolean' })
     .option('reason', { type: 'string' })
     .option('save', { type: 'boolean' })
     .parseSync();
@@ -581,6 +586,7 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
           regressFromReport: argv.fromReport,
           regressDryRun: argv.dryRun ?? undefined,
           regressOutput: argv.output,
+          regressForce: argv.force ?? undefined,
         }
       : {}),
   };
@@ -684,6 +690,7 @@ export async function runCli(
             fromReport: parsedArgs.regressFromReport,
             dryRun: parsedArgs.regressDryRun,
             output: parsedArgs.regressOutput,
+            force: parsedArgs.regressForce,
           },
           { log: dependencies.log, error: dependencies.error, cwd: process.cwd() }
         );

--- a/src/commands/regress.test.ts
+++ b/src/commands/regress.test.ts
@@ -268,7 +268,9 @@ describe('runRegressCommand', () => {
       'Wrote tests/dramaturge/BUG-001__create-dialog-never-opens.spec.ts'
     );
     expect(content).toContain('@dramaturge-finding BUG-001');
-    expect(content).toContain('To re-generate: npx dramaturge regress promote BUG-001 --force');
+    expect(content).toContain(
+      'To re-generate: npx dramaturge regress promote BUG-001 --from-report dramaturge-reports/run-1 --output tests/dramaturge --force'
+    );
     expect(content).toContain('import { test, expect } from "@playwright/test";');
   });
 
@@ -335,7 +337,8 @@ describe('runRegressCommand', () => {
             findings: [
               makeFinding({
                 title: 'Create dialog */ closes\nwith comment terminator',
-                actual: 'Nothing happens */ and a newline\nis present',
+                actual:
+                  'Nothing happens */ and a newline\nis present\u2028with unicode separator\u2029',
               }),
             ],
           }),
@@ -361,6 +364,17 @@ describe('runRegressCommand', () => {
     expect(header).toContain('*\\/');
     expect(header).not.toContain('*/ closes');
     expect(header).not.toContain('newline\nis present');
+    expect(header).not.toContain('\u2028');
+    expect(header).not.toContain('\u2029');
+  });
+
+  it('includes --force in promote usage text', () => {
+    const code = runRegressCommand({ subcommand: 'promote', positional: [] }, h.deps);
+
+    expect(code).toBe(1);
+    expect(h.errors.join('\n')).toContain(
+      'Usage: dramaturge regress promote <finding-id> [--dry-run] [--output <dir>] [--force]'
+    );
   });
 
   it('refuses to promote low-quality findings', () => {

--- a/src/commands/regress.test.ts
+++ b/src/commands/regress.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { runRegressCommand, type RegressDependencies } from './regress.js';
@@ -152,22 +152,30 @@ describe('runRegressCommand', () => {
   });
 
   it('prints a generated Playwright spec for promotable findings in dry-run mode', () => {
+    const outputDir = join(h.cwd, 'tests', 'dramaturge');
     const code = runRegressCommand(
       {
         subcommand: 'promote',
         positional: ['BUG-001'],
         fromReport: h.reportDir,
         dryRun: true,
+        output: outputDir,
       },
       h.deps
     );
 
     expect(code).toBe(0);
     const output = h.logs.join('\n');
-    expect(output).toContain('// filename: bug-001-create-dialog-never-opens.spec.ts');
+    expect(output).toContain('// filename: BUG-001__create-dialog-never-opens.spec.ts');
+    expect(output).toContain('@dramaturge-spec-version 1');
+    expect(output).toContain('@dramaturge-finding BUG-001');
+    expect(output).toContain('@dramaturge-signature ["Bug","Major"');
+    expect(output).toContain('@dramaturge-origin-run 2026-05-20T18:00:00.000Z');
+    expect(output).toContain('@dramaturge-source-report dramaturge-reports');
     expect(output).toContain('import { test, expect } from "@playwright/test";');
     expect(output).toContain('await page.goto("https://example.com/checkout");');
     expect(output).toContain('button[data-testid');
+    expect(existsSync(outputDir)).toBe(false);
   });
 
   it('uses exploration ledger actions when report action rows are unavailable', () => {
@@ -236,14 +244,123 @@ describe('runRegressCommand', () => {
     );
   });
 
-  it('refuses non-dry-run promotion in the first slice', () => {
+  it('writes a generated Playwright spec for promotable findings', () => {
+    const code = runRegressCommand(
+      {
+        subcommand: 'promote',
+        positional: ['BUG-001'],
+        fromReport: h.reportDir,
+        output: 'tests/dramaturge',
+      },
+      h.deps
+    );
+
+    const outputPath = join(
+      h.cwd,
+      'tests',
+      'dramaturge',
+      'BUG-001__create-dialog-never-opens.spec.ts'
+    );
+    const content = readFileSync(outputPath, 'utf-8');
+
+    expect(code).toBe(0);
+    expect(h.logs.join('\n')).toContain(
+      'Wrote tests/dramaturge/BUG-001__create-dialog-never-opens.spec.ts'
+    );
+    expect(content).toContain('@dramaturge-finding BUG-001');
+    expect(content).toContain('To re-generate: npx dramaturge regress promote BUG-001 --force');
+    expect(content).toContain('import { test, expect } from "@playwright/test";');
+  });
+
+  it('defaults non-dry-run writes to tests/dramaturge', () => {
+    const code = runRegressCommand(
+      { subcommand: 'promote', positional: ['BUG-001'], fromReport: h.reportDir },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    expect(
+      existsSync(join(h.cwd, 'tests', 'dramaturge', 'BUG-001__create-dialog-never-opens.spec.ts'))
+    ).toBe(true);
+  });
+
+  it('refuses to overwrite an existing promoted spec without force', () => {
+    const outputPath = join(
+      h.cwd,
+      'tests',
+      'dramaturge',
+      'BUG-001__create-dialog-never-opens.spec.ts'
+    );
+
+    expect(
+      runRegressCommand(
+        { subcommand: 'promote', positional: ['BUG-001'], fromReport: h.reportDir },
+        h.deps
+      )
+    ).toBe(0);
+
     const code = runRegressCommand(
       { subcommand: 'promote', positional: ['BUG-001'], fromReport: h.reportDir },
       h.deps
     );
 
     expect(code).toBe(1);
-    expect(h.errors.join('\n')).toContain('Only --dry-run promotion is supported');
+    expect(h.errors.join('\n')).toContain('Refusing to overwrite existing regression spec');
+    expect(readFileSync(outputPath, 'utf-8')).toContain('@dramaturge-finding BUG-001');
+  });
+
+  it('overwrites an existing promoted spec with force', () => {
+    const outputDir = join(h.cwd, 'tests', 'dramaturge');
+    const outputPath = join(outputDir, 'BUG-001__create-dialog-never-opens.spec.ts');
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(outputPath, 'stale content');
+
+    const code = runRegressCommand(
+      { subcommand: 'promote', positional: ['BUG-001'], fromReport: h.reportDir, force: true },
+      h.deps
+    );
+
+    expect(code).toBe(0);
+    const content = readFileSync(outputPath, 'utf-8');
+    expect(content).toContain('@dramaturge-finding BUG-001');
+    expect(content).not.toBe('stale content');
+  });
+
+  it('escapes provenance header values before writing specs', () => {
+    rmSync(h.cwd, { recursive: true, force: true });
+    h = makeHarness(
+      makeRunResult({
+        areaResults: [
+          makeArea({
+            findings: [
+              makeFinding({
+                title: 'Create dialog */ closes\nwith comment terminator',
+                actual: 'Nothing happens */ and a newline\nis present',
+              }),
+            ],
+          }),
+        ],
+      })
+    );
+
+    const code = runRegressCommand(
+      { subcommand: 'promote', positional: ['BUG-001'], fromReport: h.reportDir },
+      h.deps
+    );
+
+    const outputPath = join(
+      h.cwd,
+      'tests',
+      'dramaturge',
+      'BUG-001__create-dialog-closes-with-comment-terminator.spec.ts'
+    );
+    const content = readFileSync(outputPath, 'utf-8');
+    const header = content.slice(0, content.indexOf(' */') + 3);
+
+    expect(code).toBe(0);
+    expect(header).toContain('*\\/');
+    expect(header).not.toContain('*/ closes');
+    expect(header).not.toContain('newline\nis present');
   });
 
   it('refuses to promote low-quality findings', () => {

--- a/src/commands/regress.ts
+++ b/src/commands/regress.ts
@@ -266,7 +266,18 @@ function promotedSpecFilename(finding: Finding): string {
 }
 
 function sanitizeHeaderValue(value: string): string {
-  return value.replace(/[\r\n]+/g, ' ').replace(/\*\//g, '*\\/');
+  return value.replace(/[\r\n\u2028\u2029]+/g, ' ').replace(/\*\//g, '*\\/');
+}
+
+function buildRegenerateCommand(options: {
+  findingId: string;
+  sourceReport: string;
+  outputDir: string;
+}): string {
+  const { findingId, sourceReport, outputDir } = options;
+  return `npx dramaturge regress promote ${sanitizeHeaderValue(findingId)} --from-report ${sanitizeHeaderValue(
+    sourceReport
+  )} --output ${sanitizeHeaderValue(outputDir)} --force`;
 }
 
 function promotedSpecContent(options: {
@@ -274,8 +285,14 @@ function promotedSpecContent(options: {
   generatedContent: string;
   report: SerializedReport;
   sourceReport: string;
+  outputDir: string;
 }): string {
-  const { finding, generatedContent, report, sourceReport } = options;
+  const { finding, generatedContent, report, sourceReport, outputDir } = options;
+  const regenerateCommand = buildRegenerateCommand({
+    findingId: finding.id,
+    sourceReport,
+    outputDir,
+  });
   const header = [
     '/**',
     ` * @dramaturge-spec-version ${REGRESSION_SPEC_VERSION}`,
@@ -284,7 +301,7 @@ function promotedSpecContent(options: {
     ` * @dramaturge-origin-run ${sanitizeHeaderValue(report.meta?.startTime ?? 'unknown')}`,
     ` * @dramaturge-source-report ${sanitizeHeaderValue(sourceReport)}`,
     ' *',
-    ` * To re-generate: npx dramaturge regress promote ${sanitizeHeaderValue(finding.id)} --force`,
+    ` * To re-generate: ${regenerateCommand}`,
     ' */',
     '',
   ];
@@ -299,7 +316,9 @@ function promoteFinding(
 ): number {
   const findingId = args.positional[0];
   if (!findingId) {
-    deps.error('Usage: dramaturge regress promote <finding-id> [--dry-run] [--output <dir>]');
+    deps.error(
+      'Usage: dramaturge regress promote <finding-id> [--dry-run] [--output <dir>] [--force]'
+    );
     return 1;
   }
 
@@ -317,13 +336,16 @@ function promoteFinding(
   }
 
   const outputDir = resolve(deps.cwd, args.output ?? DEFAULT_REGRESSION_OUTPUT_DIR);
+  const sourceReport = relativeDisplayPath(deps.cwd, reportDir);
+  const outputDirDisplay = relativeDisplayPath(deps.cwd, outputDir);
   const filename = promotedSpecFilename(match.finding);
   const outputPath = join(outputDir, filename);
   const content = promotedSpecContent({
     finding: match.finding,
     generatedContent: match.generated.content,
     report,
-    sourceReport: relativeDisplayPath(deps.cwd, reportDir),
+    sourceReport,
+    outputDir: outputDirDisplay,
   });
 
   if (args.dryRun) {

--- a/src/commands/regress.ts
+++ b/src/commands/regress.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Alex Rambasek
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 import { scoreFindingQuality } from '../judge/quality-score.js';
+import { buildFindingGroupKey } from '../report/collector.js';
 import { buildTestFileContent } from '../report/test-gen.js';
 import type {
   AreaResult,
@@ -26,6 +27,7 @@ export interface RegressCommandArgs {
   fromReport?: string;
   dryRun?: boolean;
   output?: string;
+  force?: boolean;
 }
 
 interface SerializedReportFinding {
@@ -58,6 +60,9 @@ interface GeneratedTestPreview {
   finding: Finding;
   generated: ReturnType<typeof buildTestFileContent>;
 }
+
+const DEFAULT_REGRESSION_OUTPUT_DIR = 'tests/dramaturge';
+const REGRESSION_SPEC_VERSION = 1;
 
 function resolveReportDir(cwd: string, fromReport?: string): string {
   if (fromReport) return resolve(cwd, fromReport);
@@ -234,18 +239,67 @@ function findGeneratedTest(
   return { finding, generated };
 }
 
+function relativeDisplayPath(cwd: string, path: string): string {
+  const displayPath = relative(cwd, path);
+  if (!displayPath || displayPath.startsWith('..') || isAbsolute(displayPath)) {
+    return path.replace(/\\/g, '/');
+  }
+  return displayPath.replace(/\\/g, '/');
+}
+
+function slugifyTitle(title: string): string {
+  const slug = title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return (slug || 'regression').slice(0, 80).replace(/-+$/g, '') || 'regression';
+}
+
+function sanitizeFindingId(findingId: string): string {
+  return findingId.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'finding';
+}
+
+function promotedSpecFilename(finding: Finding): string {
+  return `${sanitizeFindingId(finding.id)}__${slugifyTitle(finding.title)}.spec.ts`;
+}
+
+function sanitizeHeaderValue(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').replace(/\*\//g, '*\\/');
+}
+
+function promotedSpecContent(options: {
+  finding: Finding;
+  generatedContent: string;
+  report: SerializedReport;
+  sourceReport: string;
+}): string {
+  const { finding, generatedContent, report, sourceReport } = options;
+  const header = [
+    '/**',
+    ` * @dramaturge-spec-version ${REGRESSION_SPEC_VERSION}`,
+    ` * @dramaturge-finding ${sanitizeHeaderValue(finding.id)}`,
+    ` * @dramaturge-signature ${sanitizeHeaderValue(buildFindingGroupKey(finding))}`,
+    ` * @dramaturge-origin-run ${sanitizeHeaderValue(report.meta?.startTime ?? 'unknown')}`,
+    ` * @dramaturge-source-report ${sanitizeHeaderValue(sourceReport)}`,
+    ' *',
+    ` * To re-generate: npx dramaturge regress promote ${sanitizeHeaderValue(finding.id)} --force`,
+    ' */',
+    '',
+  ];
+  return `${header.join('\n')}${generatedContent}`;
+}
+
 function promoteFinding(
   args: RegressCommandArgs,
   report: SerializedReport,
+  reportDir: string,
   deps: RegressDependencies
 ): number {
   const findingId = args.positional[0];
   if (!findingId) {
-    deps.error('Usage: dramaturge regress promote <finding-id> --dry-run');
-    return 1;
-  }
-  if (!args.dryRun) {
-    deps.error('Only --dry-run promotion is supported in this first slice.');
+    deps.error('Usage: dramaturge regress promote <finding-id> [--dry-run] [--output <dir>]');
     return 1;
   }
 
@@ -262,8 +316,33 @@ function promoteFinding(
     return 1;
   }
 
-  deps.log(`// filename: ${match.generated.filename}`);
-  deps.log(match.generated.content);
+  const outputDir = resolve(deps.cwd, args.output ?? DEFAULT_REGRESSION_OUTPUT_DIR);
+  const filename = promotedSpecFilename(match.finding);
+  const outputPath = join(outputDir, filename);
+  const content = promotedSpecContent({
+    finding: match.finding,
+    generatedContent: match.generated.content,
+    report,
+    sourceReport: relativeDisplayPath(deps.cwd, reportDir),
+  });
+
+  if (args.dryRun) {
+    deps.log(`// filename: ${filename}`);
+    deps.log(content);
+    return 0;
+  }
+
+  if (existsSync(outputPath) && !args.force) {
+    deps.error(
+      `Refusing to overwrite existing regression spec: ${relativeDisplayPath(deps.cwd, outputPath)}`
+    );
+    deps.error('Re-run with --force to replace it.');
+    return 1;
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+  writeFileSync(outputPath, content);
+  deps.log(`Wrote ${relativeDisplayPath(deps.cwd, outputPath)}`);
   return 0;
 }
 
@@ -277,7 +356,7 @@ export function runRegressCommand(args: RegressCommandArgs, deps: RegressDepende
         deps.log(renderList(report));
         return 0;
       case 'promote':
-        return promoteFinding(args, report, deps);
+        return promoteFinding(args, report, reportDir, deps);
       default:
         deps.error(`Unknown regress subcommand: ${args.subcommand}`);
         return 1;

--- a/src/yargs.d.ts
+++ b/src/yargs.d.ts
@@ -28,6 +28,7 @@ declare module 'yargs' {
     finding?: string;
     severity?: string;
     dryRun?: boolean;
+    force?: boolean;
   }
 
   interface DramaturgeYargsInstance {


### PR DESCRIPTION
## Summary
- enable `dramaturge regress promote` to write generated Playwright specs to `tests/dramaturge` by default or an explicit `--output` directory
- protect existing promoted specs unless `--force` is supplied, while keeping `--dry-run` as a no-write preview of final content
- emit stable `<finding-id>__<title-slug>.spec.ts` filenames and sanitized Dramaturge provenance headers
- document the write workflow and CLI flags

## Review loop
- Chunk 1 reviewer: APPROVED
- Chunk 2 reviewer: APPROVED
- Deslop/simplifier pass: applied small duplicate-removal cleanup
- Architect review initially found unsafe header interpolation; fixed with header sanitization and regression coverage
- Final reviewer + architect: APPROVED

## Verification
- `pnpm exec vitest run src/commands/regress.test.ts src/cli.test.ts src/report/test-gen.test.ts --coverage.enabled=false`
- `pnpm run build`
- `pnpm run lint` (passes with 33 pre-existing warnings)
- `pnpm run test` (141 files / 1313 tests passed)
- `git diff --check`
- `pnpm exec prettier --check src/commands/regress.ts src/commands/regress.test.ts src/cli.ts src/cli.test.ts src/yargs.d.ts README.md`

## Notes
- Repo-wide `pnpm run format:check` still reports pre-existing unrelated formatting drift across 76 files; changed files pass Prettier.

Refs #181