### PR TITLE
[codex] Make cost budgets enforceable during exploration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -334,9 +334,8 @@ const BudgetSchema = z
     stagnationThreshold: z.number().int().min(0).default(8),
     /**
      * Maximum estimated LLM cost in USD before stopping the run (0 = unlimited).
-     * Experimental — the engine does not yet enforce this automatically.
-     * Use `CostTracker` from `src/coverage/cost-tracker.ts` to track spend and
-     * check `overBudget` in a custom integration.
+     * Experimental — enforcement is approximate because some provider SDK calls
+     * do not expose authoritative token usage.
      */
     costLimitUsd: z.number().min(0).default(0),
   })

--- a/src/coverage/cost-tracker.test.ts
+++ b/src/coverage/cost-tracker.test.ts
@@ -31,6 +31,15 @@ describe("estimateCallCost", () => {
     const withoutPrefix = estimateCallCost("claude-haiku-4-5", 1000, 500);
     expect(withPrefix).toBe(withoutPrefix);
   });
+
+  it("prices Anthropic cache tokens at cache-specific rates", () => {
+    const cost = estimateCallCost("anthropic/claude-sonnet-4-6", 0, 0, {
+      cacheReadInputTokens: 1_000_000,
+      cacheCreationInputTokens: 1_000_000,
+    });
+
+    expect(cost).toBeCloseTo(4.05, 2);
+  });
 });
 
 describe("approximateTokenCount", () => {
@@ -95,6 +104,8 @@ describe("CostTracker", () => {
     expect(Object.keys(summary.byModel)).toHaveLength(2);
     expect(summary.byModel["claude-haiku-4-5"].calls).toBe(2);
     expect(summary.byModel["claude-sonnet-4-6"].calls).toBe(1);
+    expect(summary.byLabel["call-1"].calls).toBe(1);
+    expect(summary.budgetLimitUsd).toBe(50);
     expect(summary.overBudget).toBe(false);
   });
 
@@ -113,6 +124,20 @@ describe("CostTracker", () => {
     expect(record.outputTokens).toBe(2000);
     expect(record.costUsd).toBeGreaterThan(0);
     expect(record.label).toBe("test-label");
+    expect(record.source).toBe("estimated");
     expect(record.timestamp).toBeTruthy();
+  });
+
+  it("records provider-reported cache token metadata", () => {
+    const tracker = new CostTracker();
+    const record = tracker.record("anthropic/claude-sonnet-4-6", 5000, 2000, "test-label", {
+      cacheReadInputTokens: 1000,
+      cacheCreationInputTokens: 500,
+      source: "reported",
+    });
+
+    expect(record.cacheReadInputTokens).toBe(1000);
+    expect(record.cacheCreationInputTokens).toBe(500);
+    expect(record.source).toBe("reported");
   });
 });

--- a/src/coverage/cost-tracker.ts
+++ b/src/coverage/cost-tracker.ts
@@ -16,9 +16,12 @@ export interface CostRecord {
   readonly model: string;
   readonly inputTokens: number;
   readonly outputTokens: number;
+  readonly cacheReadInputTokens?: number;
+  readonly cacheCreationInputTokens?: number;
   readonly costUsd: number;
   readonly timestamp: string;
   readonly label: string;
+  readonly source: 'reported' | 'estimated';
 }
 
 export interface CostSummary {
@@ -26,23 +29,57 @@ export interface CostSummary {
   totalInputTokens: number;
   totalOutputTokens: number;
   callCount: number;
+  budgetLimitUsd?: number;
   byModel: Record<string, { costUsd: number; calls: number }>;
+  byLabel: Record<string, { costUsd: number; calls: number }>;
   overBudget: boolean;
+}
+
+export interface CostTrackingOptions {
+  costTracker?: CostTracker;
+  costLabel?: string;
 }
 
 /** Per-million-token pricing for known models. */
 interface ModelPricing {
   inputPerMillion: number;
   outputPerMillion: number;
+  cacheReadPerMillion?: number;
+  cacheWritePerMillion?: number;
 }
 
 const MODEL_PRICING: Record<string, ModelPricing> = {
   // Anthropic
-  "claude-haiku-4-5": { inputPerMillion: 0.80, outputPerMillion: 4.00 },
-  "claude-haiku-4-5-20251001": { inputPerMillion: 0.80, outputPerMillion: 4.00 },
-  "claude-sonnet-4-6": { inputPerMillion: 3.00, outputPerMillion: 15.00 },
-  "claude-sonnet-4-20250514": { inputPerMillion: 3.00, outputPerMillion: 15.00 },
-  "claude-opus-4-5": { inputPerMillion: 15.00, outputPerMillion: 75.00 },
+  "claude-haiku-4-5": {
+    inputPerMillion: 0.80,
+    outputPerMillion: 4.00,
+    cacheReadPerMillion: 0.08,
+    cacheWritePerMillion: 1.00,
+  },
+  "claude-haiku-4-5-20251001": {
+    inputPerMillion: 0.80,
+    outputPerMillion: 4.00,
+    cacheReadPerMillion: 0.08,
+    cacheWritePerMillion: 1.00,
+  },
+  "claude-sonnet-4-6": {
+    inputPerMillion: 3.00,
+    outputPerMillion: 15.00,
+    cacheReadPerMillion: 0.30,
+    cacheWritePerMillion: 3.75,
+  },
+  "claude-sonnet-4-20250514": {
+    inputPerMillion: 3.00,
+    outputPerMillion: 15.00,
+    cacheReadPerMillion: 0.30,
+    cacheWritePerMillion: 3.75,
+  },
+  "claude-opus-4-5": {
+    inputPerMillion: 15.00,
+    outputPerMillion: 75.00,
+    cacheReadPerMillion: 1.50,
+    cacheWritePerMillion: 18.75,
+  },
   // OpenAI
   "gpt-4o": { inputPerMillion: 2.50, outputPerMillion: 10.00 },
   "gpt-4o-mini": { inputPerMillion: 0.15, outputPerMillion: 0.60 },
@@ -86,12 +123,20 @@ function lookupPricing(model: string): ModelPricing {
 export function estimateCallCost(
   model: string,
   inputTokens: number,
-  outputTokens: number
+  outputTokens: number,
+  options: {
+    cacheReadInputTokens?: number;
+    cacheCreationInputTokens?: number;
+  } = {}
 ): number {
   const pricing = lookupPricing(model);
   return (
     (inputTokens / 1_000_000) * pricing.inputPerMillion +
-    (outputTokens / 1_000_000) * pricing.outputPerMillion
+    (outputTokens / 1_000_000) * pricing.outputPerMillion +
+    ((options.cacheReadInputTokens ?? 0) / 1_000_000) *
+      (pricing.cacheReadPerMillion ?? pricing.inputPerMillion) +
+    ((options.cacheCreationInputTokens ?? 0) / 1_000_000) *
+      (pricing.cacheWritePerMillion ?? pricing.inputPerMillion)
   );
 }
 
@@ -118,16 +163,27 @@ export class CostTracker {
     model: string,
     inputTokens: number,
     outputTokens: number,
-    label: string
+    label: string,
+    options: {
+      cacheReadInputTokens?: number;
+      cacheCreationInputTokens?: number;
+      source?: 'reported' | 'estimated';
+    } = {}
   ): CostRecord {
-    const costUsd = estimateCallCost(model, inputTokens, outputTokens);
+    const costUsd = estimateCallCost(model, inputTokens, outputTokens, {
+      cacheReadInputTokens: options.cacheReadInputTokens,
+      cacheCreationInputTokens: options.cacheCreationInputTokens,
+    });
     const entry: CostRecord = {
       model: stripProviderPrefix(model),
       inputTokens,
       outputTokens,
+      cacheReadInputTokens: options.cacheReadInputTokens,
+      cacheCreationInputTokens: options.cacheCreationInputTokens,
       costUsd,
       timestamp: new Date().toISOString(),
       label,
+      source: options.source ?? 'estimated',
     };
     this.records.push(entry);
     return entry;
@@ -146,6 +202,7 @@ export class CostTracker {
   /** Get a summary of all tracked costs. */
   getSummary(): CostSummary {
     const byModel: Record<string, { costUsd: number; calls: number }> = {};
+    const byLabel: Record<string, { costUsd: number; calls: number }> = {};
     let totalInputTokens = 0;
     let totalOutputTokens = 0;
 
@@ -160,6 +217,14 @@ export class CostTracker {
       } else {
         byModel[record.model] = { costUsd: record.costUsd, calls: 1 };
       }
+
+      const existingLabel = byLabel[record.label];
+      if (existingLabel) {
+        existingLabel.costUsd += record.costUsd;
+        existingLabel.calls += 1;
+      } else {
+        byLabel[record.label] = { costUsd: record.costUsd, calls: 1 };
+      }
     }
 
     return {
@@ -167,7 +232,12 @@ export class CostTracker {
       totalInputTokens,
       totalOutputTokens,
       callCount: this.records.length,
+      budgetLimitUsd:
+        Number.isFinite(this.budgetLimitUsd) && this.budgetLimitUsd >= 0
+          ? this.budgetLimitUsd
+          : undefined,
       byModel,
+      byLabel,
       overBudget: this.overBudget,
     };
   }

--- a/src/coverage/vision-analysis.ts
+++ b/src/coverage/vision-analysis.ts
@@ -5,6 +5,7 @@ import { shortId } from '../constants.js';
 import { hasLLMApiKey } from '../llm.js';
 import { sendVisionCompletion } from '../llm/index.js';
 import { UNTRUSTED_PROMPT_INSTRUCTION, wrapUntrustedPromptContent } from '../prompt-safety.js';
+import type { CostTracker } from './cost-tracker.js';
 import type { Evidence, RawFinding, FindingSeverity, FindingCategory, PageType } from '../types.js';
 
 export interface VisionAnalysisOptions {
@@ -15,6 +16,7 @@ export interface VisionAnalysisOptions {
   fullPage: boolean;
   maxResponseTokens: number;
   requestTimeoutMs: number;
+  costTracker?: CostTracker;
 }
 
 export interface VisionAnalysisResult {
@@ -156,6 +158,8 @@ ${wrapUntrustedPromptContent(
     pageContext,
     maxTokens: options.maxResponseTokens,
     requestTimeoutMs: options.requestTimeoutMs,
+    costTracker: options.costTracker,
+    costLabel: 'vision:page-analysis',
   });
 
   const analysis = parseVisionResponse(raw);

--- a/src/engine/context.ts
+++ b/src/engine/context.ts
@@ -10,6 +10,7 @@ import type {
   RawFinding,
   Evidence,
   ReplayableAction,
+  RunPartialReason,
 } from '../types.js';
 import type { StateGraph } from '../graph/state-graph.js';
 import type { FrontierQueue } from '../graph/frontier.js';
@@ -63,6 +64,7 @@ export interface EngineContext {
   errorCollector: BrowserErrorCollector;
   pageNodeOwners: Map<string, string>;
   completedTaskIds: Set<string>;
+  partialReason?: RunPartialReason;
   workerPool: WorkerSession[];
   repoHints?: RepoHints;
   contractIndex?: ContractIndex;

--- a/src/engine/cost-ledger.ts
+++ b/src/engine/cost-ledger.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { appendToLedger, mergeLedgerEntries, type LedgerContext } from '../ledger.js';
+import type { EngineContext } from './context.js';
+
+export function appendNewCostRecords(ctx: EngineContext, context: LedgerContext): void {
+  const allCostRecords = ctx.costTracker?.getRecords() ?? [];
+  const newCostRecords = allCostRecords.slice(ctx.costLedgerCursor);
+  if (newCostRecords.length === 0) {
+    return;
+  }
+  ctx.costLedgerCursor = allCostRecords.length;
+  ctx.runLedger = appendToLedger(
+    ctx.runLedger,
+    mergeLedgerEntries({
+      actionRecorderActions: [],
+      evidence: [],
+      findings: [],
+      costRecords: newCostRecords,
+      context,
+    })
+  );
+}

--- a/src/engine/execute-frontier-item.ts
+++ b/src/engine/execute-frontier-item.ts
@@ -189,6 +189,7 @@ async function runPreflightScans(
         fullPage: ctx.config.visionAnalysis.fullPage,
         maxResponseTokens: ctx.config.visionAnalysis.maxResponseTokens,
         requestTimeoutMs: ctx.config.visionAnalysis.requestTimeoutMs,
+        costTracker: ctx.costTracker,
       });
       preflightFindings.push(...visionResult.findings);
       preflightEvidence.push(...visionResult.evidence);
@@ -256,6 +257,7 @@ async function runMainWorkerTask(
       judgeConfig: ctx.config.judge,
       visionContext,
       safetyGuard: ctx.safetyGuard,
+      costTracker: ctx.costTracker,
       a2aContext,
     }
   );
@@ -294,6 +296,28 @@ function appendApiContractResults(deps: ApiContractDeps): void {
     });
     ctx.runLedger = appendToLedger(ctx.runLedger, contractLedger);
   }
+}
+
+function appendNewCostRecords(
+  ctx: EngineContext,
+  context: { areaName: string; stateId: string; taskId: string }
+): void {
+  const allCostRecords = ctx.costTracker?.getRecords() ?? [];
+  const newCostRecords = allCostRecords.slice(ctx.costLedgerCursor);
+  if (newCostRecords.length === 0) {
+    return;
+  }
+  ctx.costLedgerCursor = allCostRecords.length;
+  ctx.runLedger = appendToLedger(
+    ctx.runLedger,
+    mergeLedgerEntries({
+      actionRecorderActions: [],
+      evidence: [],
+      findings: [],
+      costRecords: newCostRecords,
+      context,
+    })
+  );
 }
 
 export async function executeFrontierItem(
@@ -358,6 +382,7 @@ export async function executeFrontierItem(
 
   if (item.workerType === 'api') {
     const result = await runApiWorkerPath({ ctx, page, item, node, observedApiEndpoints });
+    appendNewCostRecords(ctx, { areaName, stateId: node.id, taskId: item.id });
     return { item, result };
   }
 
@@ -393,6 +418,7 @@ export async function executeFrontierItem(
     stateId: node.id,
     taskId: item.id,
   });
+  appendNewCostRecords(ctx, { areaName, stateId: node.id, taskId: item.id });
 
   return { item, result };
 }

--- a/src/engine/execute-frontier-item.ts
+++ b/src/engine/execute-frontier-item.ts
@@ -17,6 +17,7 @@ import { buildApiContractArtifacts } from '../api/contract-oracle.js';
 import { summarizeContractIndex } from '../spec/contract-index.js';
 import { appendToLedger, mergeLedgerEntries } from '../ledger.js';
 import type { ObservedApiEndpoint } from '../network/traffic-observer.js';
+import { appendNewCostRecords } from './cost-ledger.js';
 
 type StagehandPage = ReturnType<Stagehand['context']['pages']>[number];
 
@@ -296,28 +297,6 @@ function appendApiContractResults(deps: ApiContractDeps): void {
     });
     ctx.runLedger = appendToLedger(ctx.runLedger, contractLedger);
   }
-}
-
-function appendNewCostRecords(
-  ctx: EngineContext,
-  context: { areaName: string; stateId: string; taskId: string }
-): void {
-  const allCostRecords = ctx.costTracker?.getRecords() ?? [];
-  const newCostRecords = allCostRecords.slice(ctx.costLedgerCursor);
-  if (newCostRecords.length === 0) {
-    return;
-  }
-  ctx.costLedgerCursor = allCostRecords.length;
-  ctx.runLedger = appendToLedger(
-    ctx.runLedger,
-    mergeLedgerEntries({
-      actionRecorderActions: [],
-      evidence: [],
-      findings: [],
-      costRecords: newCostRecords,
-      context,
-    })
-  );
 }
 
 export async function executeFrontierItem(

--- a/src/engine/finalize-run.ts
+++ b/src/engine/finalize-run.ts
@@ -20,11 +20,12 @@ export interface FinalizeRunOptions {
 }
 
 function recordRemainingBlindSpots(ctx: EngineContext, remaining: FrontierItem[]): void {
+  const reason = ctx.partialReason === 'cost-budget-exceeded' ? 'cost-budget' : 'time-budget';
   for (const item of remaining) {
     ctx.globalCoverage.addBlindSpot({
       nodeId: item.nodeId,
       summary: `Not reached: ${item.objective}`,
-      reason: 'time-budget',
+      reason,
       severity: item.priority > 0.7 ? 'high' : 'low',
     });
   }

--- a/src/engine/graph-ops.ts
+++ b/src/engine/graph-ops.ts
@@ -92,6 +92,7 @@ export async function expandGraph(
             mission: ctx.mission,
             repoHints: ctx.repoHints,
             llmRequestTimeoutMs: ctx.config.llm.requestTimeoutMs,
+            costTracker: ctx.costTracker,
             memorySignals: ctx.memoryStore?.getPlannerSignals(newNode),
             diffContext: ctx.diffContext,
           })

--- a/src/engine/main-loop.test.ts
+++ b/src/engine/main-loop.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EngineEventEmitter } from './event-stream.js';
 import { runPlannerLoop } from './main-loop.js';
 import { executeFrontierItem } from './execute-frontier-item.js';
+import { appendNewCostRecords } from './cost-ledger.js';
 import {
   collectResults,
   flushOwnedBrowserErrors,
@@ -25,6 +26,10 @@ vi.mock('./graph-ops.js', () => ({
   flushOwnedBrowserErrors: vi.fn(),
   maintainFrontier: vi.fn(),
   routeFollowups: vi.fn(),
+}));
+
+vi.mock('./cost-ledger.js', () => ({
+  appendNewCostRecords: vi.fn(),
 }));
 
 describe('runPlannerLoop', () => {
@@ -134,6 +139,7 @@ describe('runPlannerLoop', () => {
     expect(vi.mocked(flushOwnedBrowserErrors)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(collectResults)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(expandGraph)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(appendNewCostRecords)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(routeFollowups)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(maintainFrontier)).toHaveBeenCalledTimes(1);
     expect(completes).toEqual(

--- a/src/engine/main-loop.test.ts
+++ b/src/engine/main-loop.test.ts
@@ -143,4 +143,69 @@ describe('runPlannerLoop', () => {
       ])
     );
   });
+
+  it('stops before dequeuing more work when the cost budget is exhausted', async () => {
+    const item = {
+      id: 'task-1',
+      nodeId: 'node-1',
+      workerType: 'navigation',
+      objective: 'Explore home',
+      priority: 1,
+      reason: 'test',
+      retryCount: 0,
+      createdAt: new Date().toISOString(),
+      status: 'pending',
+    } as const;
+    const frontier = {
+      hasItems: () => true,
+      dequeueHighest: vi.fn(() => item),
+      requeue: vi.fn(),
+      size: () => 1,
+    };
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    const ctx = {
+      frontier,
+      eventStream: new EngineEventEmitter(),
+      config: {
+        concurrency: { workers: 1 },
+        budget: {},
+      },
+      budget: {
+        globalTimeLimitSeconds: 60,
+        maxStepsPerTask: 5,
+        maxFrontierSize: 200,
+        maxStateNodes: 50,
+      },
+      costTracker: {
+        overBudget: true,
+        getSummary: () => ({ totalCostUsd: 1.23 }),
+      },
+      graph: {
+        nodeCount: () => 0,
+      },
+      logger,
+      globalCoverage: {
+        addBlindSpot: vi.fn(),
+      },
+    } as any;
+
+    const result = await runPlannerLoop(ctx, {
+      initialTasksExecuted: 0,
+      useLLMPlanner: false,
+      checkpointInterval: 0,
+      startMs: Date.now(),
+    });
+
+    expect(result.tasksExecuted).toBe(0);
+    expect(result.partialReason).toBe('cost-budget-exceeded');
+    expect(frontier.dequeueHighest).not.toHaveBeenCalled();
+    expect(executeFrontierItem).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith('Cost budget exhausted', {
+      totalCostUsd: 1.23,
+      costLimitUsd: undefined,
+    });
+  });
 });

--- a/src/engine/main-loop.ts
+++ b/src/engine/main-loop.ts
@@ -7,6 +7,7 @@ import { MAX_NAV_RETRIES } from '../constants.js';
 import type { FrontierItem, WorkerResult } from '../types.js';
 import { executeFrontierItem } from './execute-frontier-item.js';
 import type { EngineContext } from './context.js';
+import { appendNewCostRecords } from './cost-ledger.js';
 import {
   assignPageNodeOwner,
   collectResults,
@@ -298,6 +299,11 @@ export async function runPlannerLoop(
       totalFindingsCount += result.findings.length;
 
       await expandGraph(ctx, item.nodeId, result, useLLMPlanner);
+      appendNewCostRecords(ctx, {
+        areaName: item.objective,
+        stateId: item.nodeId,
+        taskId: item.id,
+      });
       routeFollowups(ctx, item.nodeId, result);
       updateWorkflowAutomataRuntime(ctx);
 

--- a/src/engine/main-loop.ts
+++ b/src/engine/main-loop.ts
@@ -60,6 +60,7 @@ export interface RunPlannerLoopResult {
   tasksExecuted: number;
   totalFindingsCount: number;
   finalFrontierSnapshot: FrontierItem[] | undefined;
+  partialReason?: EngineContext['partialReason'];
 }
 
 function findRootNode(ctx: EngineContext): { id: string } | undefined {
@@ -106,6 +107,10 @@ function resolveTaskTimeoutMs(ctx: EngineContext, startMs: number): number {
     Math.max(MIN_DERIVED_TASK_TIMEOUT_MS, derived)
   );
   return Math.max(1, Math.min(remainingMs, bounded));
+}
+
+function costBudgetExceeded(ctx: EngineContext): boolean {
+  return ctx.costTracker?.overBudget === true;
 }
 
 async function processTaskBatch(
@@ -212,12 +217,23 @@ export async function runPlannerLoop(
   let totalFindingsCount = 0;
 
   while (ctx.frontier.hasItems()) {
+    if (costBudgetExceeded(ctx)) {
+      const summary = ctx.costTracker?.getSummary();
+      ctx.logger?.warn('Cost budget exhausted', {
+        totalCostUsd: summary?.totalCostUsd,
+        costLimitUsd: ctx.budget.costLimitUsd,
+      });
+      ctx.partialReason = 'cost-budget-exceeded';
+      break;
+    }
+
     const elapsedMs = Date.now() - startMs;
     if (elapsedMs > ctx.budget.globalTimeLimitSeconds * 1000) {
       ctx.logger?.warn('Time budget exhausted', {
         elapsedMs,
         timeLimitMs: ctx.budget.globalTimeLimitSeconds * 1000,
       });
+      ctx.partialReason = 'time-budget-exceeded';
       break;
     }
 
@@ -353,5 +369,6 @@ export async function runPlannerLoop(
     tasksExecuted,
     totalFindingsCount,
     finalFrontierSnapshot: checkpointInterval > 0 ? ctx.frontier.snapshot() : undefined,
+    partialReason: ctx.partialReason,
   };
 }

--- a/src/engine/reports.ts
+++ b/src/engine/reports.ts
@@ -53,6 +53,13 @@ export function buildAreaResults(ctx: EngineContext): AreaResult[] {
   return results;
 }
 
+function resolvePartialReason(
+  ctx: EngineContext,
+  remaining: FrontierItem[]
+): RunResult['partialReason'] {
+  return ctx.partialReason ?? (remaining.length > 0 ? 'frontier-remaining' : undefined);
+}
+
 export function writeReports(
   ctx: EngineContext,
   startTime: Date,
@@ -89,6 +96,7 @@ export function writeReports(
     })),
     {
       partial: remaining.length > 0,
+      partialReason: resolvePartialReason(ctx, remaining),
       blindSpots,
       stateGraphMermaid,
       runConfig: {
@@ -99,6 +107,7 @@ export function writeReports(
           timeLimitSeconds: ctx.budget.globalTimeLimitSeconds,
           maxStepsPerTask: ctx.budget.maxStepsPerTask,
           maxStateNodes: ctx.budget.maxStateNodes,
+          costLimitUsd: ctx.budget.costLimitUsd,
         },
         checkpointInterval: config.checkpoint.intervalTasks,
         autoCaptureEnabled:
@@ -115,6 +124,7 @@ export function writeReports(
       diffSummary,
       crossRunClassification: ctx.crossRunClassification,
       safetyAudit,
+      costSummary: ctx.costTracker?.getSummary(),
       explorationLedger: ctx.runLedger,
       workflowAutomaton: ctx.workflowAutomata?.current,
       workflowComparison: ctx.workflowAutomata?.comparison,

--- a/src/engine/run-state.ts
+++ b/src/engine/run-state.ts
@@ -95,6 +95,7 @@ async function proposeSeedTasks(
       mission: ctx.mission,
       repoHints: ctx.repoHints,
       llmRequestTimeoutMs: ctx.config.llm.requestTimeoutMs,
+      costTracker: ctx.costTracker,
       memorySignals: ctx.memoryStore?.getPlannerSignals(node),
       diffContext: ctx.diffContext,
     });

--- a/src/engine/run-state.ts
+++ b/src/engine/run-state.ts
@@ -8,6 +8,7 @@ import { classifyPage } from '../planner/page-classifier.js';
 import type { FrontierItem, StateNode } from '../types.js';
 import type { EngineContext } from './context.js';
 import { assignPageNodeOwner } from './graph-ops.js';
+import { appendNewCostRecords } from './cost-ledger.js';
 
 export interface WarmStartState {
   warmStartApplied: boolean;
@@ -128,6 +129,7 @@ export async function seedFrontierIfNeeded(
 
     const seedTasks = await proposeSeedTasks(ctx, rootNode, useLLMPlanner);
     ctx.frontier.enqueueMany(seedTasks);
+    appendNewCostRecords(ctx, { areaName: rootNode.title ?? rootNode.id, stateId: rootNode.id });
     ctx.logger?.info('Seeded frontier from root state', {
       pageType: rootPageType,
       fingerprint: rootFingerprint.hash,
@@ -139,6 +141,7 @@ export async function seedFrontierIfNeeded(
       assignPageNodeOwner(ctx, 'primary', rootNode.id);
       const seedTasks = await proposeSeedTasks(ctx, rootNode, useLLMPlanner);
       ctx.frontier.enqueueMany(seedTasks);
+      appendNewCostRecords(ctx, { areaName: rootNode.title ?? rootNode.id, stateId: rootNode.id });
       ctx.logger?.info('Seeded frontier from existing root state', {
         nodeId: rootNode.id,
         tasks: seedTasks.length,

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -3,9 +3,27 @@
 
 import type { LLMTaskProposal, WorkerType } from './types.js';
 import type { JudgeDecision } from './judge/types.js';
+import type { CostTrackingOptions } from './coverage/cost-tracker.js';
 import { DEFAULT_LLM_TIMEOUT_MS, JUDGE_LLM_TIMEOUT_MS } from './constants.js';
 import { UNTRUSTED_PROMPT_INSTRUCTION, wrapUntrustedPromptContent } from './prompt-safety.js';
 import { hasConfiguredProvider, sendChatCompletion } from './llm/index.js';
+
+type ChatCompletionMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+interface CallLLMOptions extends CostTrackingOptions {
+  model: string;
+  system: string;
+  messages: ChatCompletionMessage[];
+  maxTokens?: number;
+  requestTimeoutMs?: number;
+}
+
+interface ProposeLLMTasksOptions extends CostTrackingOptions {
+  requestTimeoutMs?: number;
+}
 
 /**
  * Check whether the given model's provider (or any provider, if no model
@@ -21,14 +39,25 @@ function extractJsonFromResponse(raw: string): string {
   return fenceMatch ? fenceMatch[1].trim() : raw.trim();
 }
 
-async function callLLM(
-  model: string,
-  system: string,
-  messages: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>,
-  maxTokens = 1024,
-  requestTimeoutMs = DEFAULT_LLM_TIMEOUT_MS
-): Promise<string> {
-  return sendChatCompletion({ model, system, messages, maxTokens, requestTimeoutMs });
+async function callLLM(options: CallLLMOptions): Promise<string> {
+  return sendChatCompletion({
+    model: options.model,
+    system: options.system,
+    messages: options.messages,
+    maxTokens: options.maxTokens ?? 1024,
+    requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_LLM_TIMEOUT_MS,
+    costTracker: options.costTracker,
+    costLabel: options.costLabel,
+  });
+}
+
+function normalizeProposeOptions(
+  options: number | ProposeLLMTasksOptions | undefined
+): ProposeLLMTasksOptions {
+  if (typeof options === 'number') {
+    return { requestTimeoutMs: options };
+  }
+  return options ?? {};
 }
 
 export async function proposeLLMTasks(
@@ -36,8 +65,9 @@ export async function proposeLLMTasks(
   graphSummary: string,
   nodeDescription: string,
   allowedWorkerTypes: WorkerType[],
-  requestTimeoutMs = 30_000
+  options?: number | ProposeLLMTasksOptions
 ): Promise<LLMTaskProposal[] | null> {
+  const { requestTimeoutMs = 30_000, ...costOptions } = normalizeProposeOptions(options);
   const system = `You are a QA test planner analyzing a web application's state graph.
 Your job is to propose focused testing tasks for a specific page.
 
@@ -63,13 +93,15 @@ ${wrapUntrustedPromptContent('PAGE DESCRIPTION', nodeDescription)}
 Propose testing tasks for this page.`;
 
   try {
-    const raw = await callLLM(
+    const raw = await callLLM({
       model,
       system,
-      [{ role: 'user', content: userPrompt }],
-      1024,
-      requestTimeoutMs
-    );
+      messages: [{ role: 'user', content: userPrompt }],
+      maxTokens: 1024,
+      requestTimeoutMs,
+      costLabel: 'planner:propose-tasks',
+      ...costOptions,
+    });
 
     // Extract JSON from response (handle possible markdown code fences)
     const jsonStr = extractJsonFromResponse(raw);
@@ -114,7 +146,8 @@ Propose testing tasks for this page.`;
 export async function judgeObservationWithLLM(
   model: string,
   prompt: string,
-  requestTimeoutMs = JUDGE_LLM_TIMEOUT_MS
+  requestTimeoutMs = JUDGE_LLM_TIMEOUT_MS,
+  costOptions: CostTrackingOptions = {}
 ): Promise<JudgeDecision> {
   const system = `You are a QA evidence judge.
 Return a single JSON object with exactly these keys:
@@ -130,13 +163,15 @@ Return ONLY JSON. No markdown fences, no explanation.`;
 
 ${wrapUntrustedPromptContent('JUDGE INPUT', prompt)}`;
 
-  const raw = await callLLM(
+  const raw = await callLLM({
     model,
     system,
-    [{ role: 'user', content: safePrompt }],
-    512,
-    requestTimeoutMs
-  );
+    messages: [{ role: 'user', content: safePrompt }],
+    maxTokens: 512,
+    requestTimeoutMs,
+    costLabel: 'judge:observation',
+    ...costOptions,
+  });
   const jsonStr = extractJsonFromResponse(raw);
   let parsed: Partial<JudgeDecision> & { confidence?: 'low' | 'medium' | 'high' };
   try {

--- a/src/llm/client.test.ts
+++ b/src/llm/client.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { sendChatCompletion, sendVisionCompletion, redactApiKey } from './client.js';
+import { CostTracker } from '../coverage/cost-tracker.js';
 
 describe('client', () => {
   const originalFetch = globalThis.fetch;
@@ -64,6 +65,80 @@ describe('client', () => {
       );
       const body = JSON.parse((init as RequestInit).body as string);
       expect(body.model).toBe('claude-sonnet-4-6');
+    });
+
+    it('records provider-reported usage for successful chat completions', async () => {
+      process.env.ANTHROPIC_API_KEY = 'test-anthropic-key';
+      const costTracker = new CostTracker();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          content: [{ type: 'text', text: 'Hello from Anthropic' }],
+          usage: {
+            input_tokens: 123,
+            output_tokens: 45,
+            cache_read_input_tokens: 20,
+            cache_creation_input_tokens: 10,
+          },
+        }),
+      }) as unknown as typeof fetch;
+
+      await sendChatCompletion({
+        model: 'anthropic/claude-sonnet-4-6',
+        system: 'You are helpful.',
+        messages: [{ role: 'user', content: 'Hi' }],
+        maxTokens: 100,
+        requestTimeoutMs: 5000,
+        costTracker,
+        costLabel: 'test-chat',
+      });
+
+      expect(costTracker.getRecords()).toEqual([
+        expect.objectContaining({
+          model: 'claude-sonnet-4-6',
+          label: 'test-chat',
+          inputTokens: 123,
+          outputTokens: 45,
+          cacheReadInputTokens: 20,
+          cacheCreationInputTokens: 10,
+          source: 'reported',
+        }),
+      ]);
+    });
+
+    it('records OpenAI-compatible usage from provider responses', async () => {
+      process.env.OPENAI_API_KEY = 'test-openai-key';
+      delete process.env.OPENAI_BASE_URL;
+      const costTracker = new CostTracker();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'Hello from OpenAI' } }],
+          usage: { prompt_tokens: 55, completion_tokens: 12 },
+        }),
+      }) as unknown as typeof fetch;
+
+      await sendChatCompletion({
+        model: 'openai/gpt-4.1',
+        system: 'You are helpful.',
+        messages: [{ role: 'user', content: 'Hi' }],
+        maxTokens: 100,
+        requestTimeoutMs: 5000,
+        costTracker,
+        costLabel: 'openai-usage',
+      });
+
+      expect(costTracker.getRecords()[0]).toEqual(
+        expect.objectContaining({
+          model: 'gpt-4.1',
+          label: 'openai-usage',
+          inputTokens: 55,
+          outputTokens: 12,
+          source: 'reported',
+        })
+      );
     });
 
     it('routes openai model to OpenAI API', async () => {
@@ -289,6 +364,73 @@ describe('client', () => {
       const body = JSON.parse((init as RequestInit).body as string);
       expect(body.messages[1].content[0].type).toBe('image_url');
       expect(body.messages[1].content[0].image_url.url).toContain('data:image/png;base64,');
+    });
+
+    it('records fallback estimated usage when providers omit usage data', async () => {
+      process.env.OPENAI_API_KEY = 'test-openai-key';
+      const costTracker = new CostTracker();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: 'I see a form' } }],
+        }),
+      }) as unknown as typeof fetch;
+
+      await sendVisionCompletion({
+        model: 'openai/gpt-4o',
+        system: 'Analyze this.',
+        base64Image: 'base64data',
+        pageContext: 'Page context',
+        maxTokens: 512,
+        requestTimeoutMs: 5000,
+        costTracker,
+        costLabel: 'test-vision',
+      });
+
+      expect(costTracker.getRecords()).toEqual([
+        expect.objectContaining({
+          model: 'gpt-4o',
+          label: 'test-vision',
+          inputTokens: expect.any(Number),
+          outputTokens: expect.any(Number),
+          source: 'estimated',
+        }),
+      ]);
+    });
+
+    it('records Google usage metadata for vision completions', async () => {
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY = 'test-google-key';
+      const costTracker = new CostTracker();
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: 'I see a form' }] } }],
+          usageMetadata: { promptTokenCount: 88, candidatesTokenCount: 21 },
+        }),
+      }) as unknown as typeof fetch;
+
+      await sendVisionCompletion({
+        model: 'google/gemini-2.5-pro',
+        system: 'Analyze this.',
+        base64Image: 'base64data',
+        pageContext: 'Page context',
+        maxTokens: 512,
+        requestTimeoutMs: 5000,
+        costTracker,
+        costLabel: 'google-vision',
+      });
+
+      expect(costTracker.getRecords()[0]).toEqual(
+        expect.objectContaining({
+          model: 'gemini-2.5-pro',
+          label: 'google-vision',
+          inputTokens: 88,
+          outputTokens: 21,
+          source: 'reported',
+        })
+      );
     });
   });
 });

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { TRUNCATE_GROUP_KEY } from '../constants.js';
+import { approximateTokenCount, type CostTrackingOptions } from '../coverage/cost-tracker.js';
 import type { ChatMessage, LLMProviderAdapter } from './types.js';
 import { resolveProvider, stripProviderPrefix } from './registry.js';
 
@@ -10,6 +11,29 @@ import { resolveProvider, stripProviderPrefix } from './registry.js';
  */
 export function redactApiKey(text: string, apiKey: string): string {
   return text.replaceAll(apiKey, '[REDACTED]');
+}
+
+function recordCompletionCost(options: {
+  adapter: LLMProviderAdapter;
+  response: unknown;
+  model: string;
+  inputText: string;
+  outputText: string;
+  costTracker?: CostTrackingOptions['costTracker'];
+  costLabel?: string;
+}): void {
+  const usage = options.adapter.extractUsage(options.response);
+  options.costTracker?.record(
+    options.model,
+    usage?.inputTokens ?? approximateTokenCount(options.inputText),
+    usage?.outputTokens ?? approximateTokenCount(options.outputText),
+    options.costLabel ?? 'chat-completion',
+    {
+      cacheReadInputTokens: usage?.cacheReadInputTokens,
+      cacheCreationInputTokens: usage?.cacheCreationInputTokens,
+      source: usage ? 'reported' : 'estimated',
+    }
+  );
 }
 
 /**
@@ -21,6 +45,8 @@ export async function sendChatCompletion(options: {
   messages: ChatMessage[];
   maxTokens: number;
   requestTimeoutMs: number;
+  costTracker?: CostTrackingOptions['costTracker'];
+  costLabel?: string;
 }): Promise<string> {
   const adapter = resolveProvider(options.model);
   const modelId = stripProviderPrefix(options.model);
@@ -33,7 +59,17 @@ export async function sendChatCompletion(options: {
   });
 
   const data = await executeProviderRequest(req, adapter, options.requestTimeoutMs);
-  return adapter.extractChatResponse(data);
+  const text = adapter.extractChatResponse(data);
+  recordCompletionCost({
+    adapter,
+    response: data,
+    model: options.model,
+    inputText: [options.system, ...options.messages.map((message) => message.content)].join('\n'),
+    outputText: text,
+    costTracker: options.costTracker,
+    costLabel: options.costLabel,
+  });
+  return text;
 }
 
 /**
@@ -46,6 +82,8 @@ export async function sendVisionCompletion(options: {
   pageContext: string;
   maxTokens: number;
   requestTimeoutMs: number;
+  costTracker?: CostTrackingOptions['costTracker'];
+  costLabel?: string;
 }): Promise<string> {
   const adapter = resolveProvider(options.model);
   const modelId = stripProviderPrefix(options.model);
@@ -59,7 +97,17 @@ export async function sendVisionCompletion(options: {
   });
 
   const data = await executeProviderRequest(req, adapter, options.requestTimeoutMs);
-  return adapter.extractVisionResponse(data);
+  const text = adapter.extractVisionResponse(data);
+  recordCompletionCost({
+    adapter,
+    response: data,
+    model: options.model,
+    inputText: `${options.system}\n${options.pageContext}`,
+    outputText: text,
+    costTracker: options.costTracker,
+    costLabel: options.costLabel ?? 'vision-completion',
+  });
+  return text;
 }
 
 /**

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Alex Rambasek
 
-import type { LLMProviderAdapter, ChatMessage, ProviderRequest } from '../types.js';
+import type { LLMProviderAdapter, ChatMessage, LlmUsage, ProviderRequest } from '../types.js';
 
 const API_URL = 'https://api.anthropic.com/v1/messages';
 const ENV_KEY = 'ANTHROPIC_API_KEY';
@@ -25,6 +25,39 @@ function extractText(data: unknown): string {
       .map((c) => c.text)
       .join('') ?? ''
   );
+}
+
+function extractUsage(data: unknown): LlmUsage | null {
+  const usage = (
+    data as {
+      usage?: {
+        input_tokens?: unknown;
+        output_tokens?: unknown;
+        cache_read_input_tokens?: unknown;
+        cache_creation_input_tokens?: unknown;
+      };
+    }
+  ).usage;
+  if (!usage) {
+    return null;
+  }
+
+  const inputTokens = typeof usage.input_tokens === 'number' ? usage.input_tokens : undefined;
+  const outputTokens = typeof usage.output_tokens === 'number' ? usage.output_tokens : undefined;
+  if (inputTokens === undefined && outputTokens === undefined) {
+    return null;
+  }
+
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    cacheReadInputTokens:
+      typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : undefined,
+    cacheCreationInputTokens:
+      typeof usage.cache_creation_input_tokens === 'number'
+        ? usage.cache_creation_input_tokens
+        : undefined,
+  };
 }
 
 export const anthropicProvider: LLMProviderAdapter = {
@@ -93,4 +126,6 @@ export const anthropicProvider: LLMProviderAdapter = {
   },
 
   extractVisionResponse: extractText,
+
+  extractUsage,
 };

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -35,6 +35,7 @@ function extractUsage(data: unknown): LlmUsage | null {
       usageMetadata?: {
         promptTokenCount?: unknown;
         candidatesTokenCount?: unknown;
+        thoughtsTokenCount?: unknown;
       };
     }
   ).usageMetadata;
@@ -44,8 +45,14 @@ function extractUsage(data: unknown): LlmUsage | null {
 
   const inputTokens =
     typeof usage.promptTokenCount === 'number' ? usage.promptTokenCount : undefined;
-  const outputTokens =
+  const candidateTokens =
     typeof usage.candidatesTokenCount === 'number' ? usage.candidatesTokenCount : undefined;
+  const thoughtsTokens =
+    typeof usage.thoughtsTokenCount === 'number' ? usage.thoughtsTokenCount : undefined;
+  const outputTokens =
+    candidateTokens === undefined && thoughtsTokens === undefined
+      ? undefined
+      : (candidateTokens ?? 0) + (thoughtsTokens ?? 0);
   if (inputTokens === undefined && outputTokens === undefined) {
     return null;
   }

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Alex Rambasek
 
-import type { LLMProviderAdapter, ChatMessage, ProviderRequest } from '../types.js';
+import type { LLMProviderAdapter, ChatMessage, LlmUsage, ProviderRequest } from '../types.js';
 
 const ENV_KEY = 'GOOGLE_GENERATIVE_AI_API_KEY';
 const BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
@@ -27,6 +27,33 @@ function extractText(data: unknown): string {
       .map((p) => p.text)
       .join('') ?? ''
   );
+}
+
+function extractUsage(data: unknown): LlmUsage | null {
+  const usage = (
+    data as {
+      usageMetadata?: {
+        promptTokenCount?: unknown;
+        candidatesTokenCount?: unknown;
+      };
+    }
+  ).usageMetadata;
+  if (!usage) {
+    return null;
+  }
+
+  const inputTokens =
+    typeof usage.promptTokenCount === 'number' ? usage.promptTokenCount : undefined;
+  const outputTokens =
+    typeof usage.candidatesTokenCount === 'number' ? usage.candidatesTokenCount : undefined;
+  if (inputTokens === undefined && outputTokens === undefined) {
+    return null;
+  }
+
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+  };
 }
 
 export const googleProvider: LLMProviderAdapter = {
@@ -91,4 +118,6 @@ export const googleProvider: LLMProviderAdapter = {
   },
 
   extractVisionResponse: extractText,
+
+  extractUsage,
 };

--- a/src/llm/providers/openai-compatible.ts
+++ b/src/llm/providers/openai-compatible.ts
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Alex Rambasek
 
-import type { LLMProviderAdapter, ChatMessage, ProviderId, ProviderRequest } from '../types.js';
+import type {
+  LLMProviderAdapter,
+  ChatMessage,
+  LlmUsage,
+  ProviderId,
+  ProviderRequest,
+} from '../types.js';
 
 /**
  * Configuration for creating an OpenAI-compatible provider adapter.
@@ -45,6 +51,37 @@ function extractText(data: unknown): string {
     (data as { choices?: Array<{ message?: { content?: string } }> }).choices?.[0]?.message
       ?.content ?? ''
   );
+}
+
+function firstNumber(...values: unknown[]): number | undefined {
+  return values.find((value): value is number => typeof value === 'number');
+}
+
+function extractUsage(data: unknown): LlmUsage | null {
+  const usage = (
+    data as {
+      usage?: {
+        prompt_tokens?: unknown;
+        completion_tokens?: unknown;
+        input_tokens?: unknown;
+        output_tokens?: unknown;
+      };
+    }
+  ).usage;
+  if (!usage) {
+    return null;
+  }
+
+  const inputTokens = firstNumber(usage.prompt_tokens, usage.input_tokens);
+  const outputTokens = firstNumber(usage.completion_tokens, usage.output_tokens);
+  if (inputTokens === undefined && outputTokens === undefined) {
+    return null;
+  }
+
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+  };
 }
 
 /**
@@ -162,6 +199,8 @@ export function createOpenAICompatibleProvider(config: OpenAICompatibleConfig): 
     },
 
     extractVisionResponse: extractText,
+
+    extractUsage,
   };
 }
 

--- a/src/llm/providers/providers.test.ts
+++ b/src/llm/providers/providers.test.ts
@@ -186,6 +186,17 @@ describe('provider adapters', () => {
       };
       expect(googleProvider.extractChatResponse(data)).toBe('Google says hi');
     });
+
+    it('includes thoughts tokens in extracted output usage', () => {
+      const usage = googleProvider.extractUsage({
+        usageMetadata: {
+          promptTokenCount: 7,
+          candidatesTokenCount: 11,
+          thoughtsTokenCount: 5,
+        },
+      });
+      expect(usage).toEqual({ inputTokens: 7, outputTokens: 16 });
+    });
   });
 
   describe('azureFoundryProvider', () => {

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -13,6 +13,14 @@ export interface ChatMessage {
   content: string;
 }
 
+/** Provider-reported model usage, normalized across backends. */
+export interface LlmUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
+}
+
 /** Provider identifiers used as model-string prefixes. */
 export type ProviderId =
   | 'anthropic'
@@ -74,4 +82,7 @@ export interface LLMProviderAdapter {
 
   /** Extract the assistant text from a vision response. */
   extractVisionResponse(data: unknown): string;
+
+  /** Extract normalized usage from the provider response, when available. */
+  extractUsage(data: unknown): LlmUsage | null;
 }

--- a/src/planner/planner.ts
+++ b/src/planner/planner.ts
@@ -23,6 +23,7 @@ import { computePriority, type PriorityContext } from './priority.js';
 import { proposeLLMTasks } from '../llm.js';
 import type { PlannerMemorySignals } from '../memory/types.js';
 import type { DiffContext } from '../diff/types.js';
+import type { CostTracker } from '../coverage/cost-tracker.js';
 
 /** Default page-type → worker-type mapping. */
 const PAGE_TYPE_WORKER_MAP: Record<PageType, WorkerType> = {
@@ -129,6 +130,7 @@ export interface ProposeTasksOptions {
 export interface ProposeTasksWithLLMOptions extends ProposeTasksOptions {
   plannerModel: string;
   llmRequestTimeoutMs?: number;
+  costTracker?: CostTracker;
 }
 
 const ADVERSARIAL_PAGE_TYPES = new Set<PageType>([
@@ -279,7 +281,10 @@ export class Planner {
       graph.summary(),
       nodeDesc,
       allowedTypes,
-      llmRequestTimeoutMs
+      {
+        requestTimeoutMs: llmRequestTimeoutMs,
+        costTracker: options.costTracker,
+      }
     );
 
     if (!llmProposals) {

--- a/src/report/collector.ts
+++ b/src/report/collector.ts
@@ -139,6 +139,7 @@ export function buildRunResult(
   unexploredAreas: Array<{ name: string; reason: string }>,
   options: {
     partial: boolean;
+    partialReason?: RunResult['partialReason'];
     blindSpots?: BlindSpot[];
     stateGraphMermaid?: string;
     runConfig?: RunConfigMeta;
@@ -146,6 +147,7 @@ export function buildRunResult(
     diffSummary?: DiffSummary;
     crossRunClassification?: CrossRunClassification;
     safetyAudit?: RunResult['safetyAudit'];
+    costSummary?: RunResult['costSummary'];
     explorationLedger?: RunResult['explorationLedger'];
     workflowAutomaton?: RunResult['workflowAutomaton'];
     workflowComparison?: RunResult['workflowComparison'];
@@ -153,6 +155,7 @@ export function buildRunResult(
 ): RunResult {
   const {
     partial,
+    partialReason,
     blindSpots = [],
     stateGraphMermaid,
     runConfig,
@@ -160,6 +163,7 @@ export function buildRunResult(
     diffSummary,
     crossRunClassification,
     safetyAudit,
+    costSummary,
     explorationLedger,
     workflowAutomaton,
     workflowComparison,
@@ -172,6 +176,7 @@ export function buildRunResult(
     areaResults,
     unexploredAreas,
     partial,
+    partialReason,
     blindSpots,
     stateGraphMermaid,
     runConfig,
@@ -179,6 +184,7 @@ export function buildRunResult(
     diffSummary,
     crossRunClassification,
     safetyAudit,
+    costSummary,
     explorationLedger,
     workflowAutomaton,
     workflowComparison,

--- a/src/report/json.ts
+++ b/src/report/json.ts
@@ -1,8 +1,60 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 Alex Rambasek
 
-import type { RunResult } from '../types.js';
+import type { CrossRunClassification, Finding, RunResult } from '../types.js';
 import { collectFindings } from './collector.js';
+
+function renderFindingTrace(
+  finding: Finding
+): { actionIds: string[]; evidenceIds: string[] } | null {
+  const hasTrace =
+    (finding.meta?.repro?.actionIds?.length ?? 0) > 0 ||
+    (finding.meta?.repro?.evidenceIds?.length ?? 0) > 0;
+  if (!hasTrace) {
+    return null;
+  }
+  return {
+    actionIds: finding.meta?.repro?.actionIds ?? [],
+    evidenceIds: finding.meta?.repro?.evidenceIds ?? [],
+  };
+}
+
+function renderCrossRunStatus(
+  finding: Finding,
+  classification: CrossRunClassification | undefined
+): Omit<NonNullable<CrossRunClassification['byFindingId'][string]>, 'signature'> | null {
+  const status = classification?.byFindingId[finding.id];
+  if (!status) {
+    return null;
+  }
+  const { signature: _signature, ...sanitizedStatus } = status;
+  return sanitizedStatus;
+}
+
+function renderFinding(
+  finding: Finding,
+  classification: CrossRunClassification | undefined
+): Record<string, unknown> {
+  return {
+    id: finding.id,
+    category: finding.category,
+    severity: finding.severity,
+    area: finding.area,
+    title: finding.title,
+    stepsToReproduce: finding.stepsToReproduce,
+    expected: finding.expected,
+    actual: finding.actual,
+    screenshot: finding.screenshot ?? null,
+    evidenceIds: finding.evidenceIds ?? [],
+    verdict: finding.verdict ?? null,
+    trace: renderFindingTrace(finding),
+    occurrenceCount: finding.occurrenceCount,
+    impactedAreas: finding.impactedAreas,
+    occurrences: finding.occurrences,
+    meta: finding.meta ?? null,
+    crossRunStatus: renderCrossRunStatus(finding, classification),
+  };
+}
 
 export function renderJson(result: RunResult): string {
   const findings = collectFindings(result.areaResults);
@@ -22,6 +74,7 @@ export function renderJson(result: RunResult): string {
       endTime: result.endTime.toISOString(),
       durationMs: duration,
       partial: result.partial,
+      partialReason: result.partialReason ?? null,
     },
     summary: {
       areasExplored: result.areaResults.filter((a) => a.status === 'explored').length,
@@ -45,38 +98,7 @@ export function renderJson(result: RunResult): string {
         ])
       ),
     },
-    findings: findings.map((f) => ({
-      id: f.id,
-      category: f.category,
-      severity: f.severity,
-      area: f.area,
-      title: f.title,
-      stepsToReproduce: f.stepsToReproduce,
-      expected: f.expected,
-      actual: f.actual,
-      screenshot: f.screenshot ?? null,
-      evidenceIds: f.evidenceIds ?? [],
-      verdict: f.verdict ?? null,
-      trace:
-        (f.meta?.repro?.actionIds?.length ?? 0) > 0 || (f.meta?.repro?.evidenceIds?.length ?? 0) > 0
-          ? {
-              actionIds: f.meta?.repro?.actionIds ?? [],
-              evidenceIds: f.meta?.repro?.evidenceIds ?? [],
-            }
-          : null,
-      occurrenceCount: f.occurrenceCount,
-      impactedAreas: f.impactedAreas,
-      occurrences: f.occurrences,
-      meta: f.meta ?? null,
-      crossRunStatus: (() => {
-        const status = result.crossRunClassification?.byFindingId[f.id];
-        if (!status) {
-          return null;
-        }
-        const { signature: _signature, ...sanitizedStatus } = status;
-        return sanitizedStatus;
-      })(),
-    })),
+    findings: findings.map((finding) => renderFinding(finding, result.crossRunClassification)),
     crossRunSummary: result.crossRunClassification
       ? {
           ...result.crossRunClassification.summary,
@@ -131,6 +153,7 @@ export function renderJson(result: RunResult): string {
     runConfig: result.runConfig ?? null,
     runMemory: result.runMemory ?? null,
     safetyAudit: result.safetyAudit ?? null,
+    costSummary: result.costSummary ?? null,
     explorationLedger: result.explorationLedger
       ? {
           version: result.explorationLedger.version,

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -43,6 +43,9 @@ function renderHeader(
   lines.push(`# Dramaturge Report — ${timestamp}`);
   if (result.partial) {
     lines.push('> **Warning:** This run was incomplete. Some areas may not have been explored.');
+    if (result.partialReason) {
+      lines.push(`> Reason: \`${result.partialReason}\`.`);
+    }
     lines.push('');
   }
   lines.push(`**Target:** ${escapeMarkdownInline(result.targetUrl)}`);
@@ -473,6 +476,51 @@ function renderRunConfigSection(result: RunResult): string[] {
   ];
 }
 
+function renderCostSummarySection(result: RunResult): string[] {
+  if (!result.costSummary) return [];
+  const summary = result.costSummary;
+  const lines = [
+    '## Cost Summary',
+    '',
+    `- **Estimated cost:** $${summary.totalCostUsd.toFixed(6)}`,
+    `- **Budget:** ${
+      summary.budgetLimitUsd === undefined ? 'unlimited' : `$${summary.budgetLimitUsd.toFixed(2)}`
+    }`,
+    `- **Model calls:** ${summary.callCount}`,
+    `- **Input tokens:** ${summary.totalInputTokens}`,
+    `- **Output tokens:** ${summary.totalOutputTokens}`,
+    `- **Over budget:** ${summary.overBudget ? 'yes' : 'no'}`,
+  ];
+  const modelEntries = Object.entries(summary.byModel);
+  if (modelEntries.length > 0) {
+    lines.push(
+      '',
+      '**By model**',
+      '',
+      '| Model | Calls | Estimated cost |',
+      '|-------|-------|----------------|'
+    );
+    for (const [model, item] of modelEntries) {
+      lines.push(`| ${escapeTableCell(model)} | ${item.calls} | $${item.costUsd.toFixed(6)} |`);
+    }
+  }
+  const labelEntries = Object.entries(summary.byLabel);
+  if (labelEntries.length > 0) {
+    lines.push(
+      '',
+      '**By call label**',
+      '',
+      '| Label | Calls | Estimated cost |',
+      '|-------|-------|----------------|'
+    );
+    for (const [label, item] of labelEntries) {
+      lines.push(`| ${escapeTableCell(label)} | ${item.calls} | $${item.costUsd.toFixed(6)} |`);
+    }
+  }
+  lines.push('');
+  return lines;
+}
+
 function renderSafetyAuditSection(result: RunResult): string[] {
   if (!result.safetyAudit) return [];
   const lines: string[] = [
@@ -540,6 +588,7 @@ export function renderMarkdown(result: RunResult): string {
     renderDiffSummarySection(result, diffScope),
     renderRunMemorySection(result),
     renderRunConfigSection(result),
+    renderCostSummarySection(result),
     renderSafetyAuditSection(result),
   ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import type { CrossRunClassification } from './report/cross-run-classification.js';
-import type { CostRecord } from './coverage/cost-tracker.js';
+import type { CostRecord, CostSummary } from './coverage/cost-tracker.js';
 import type { FindingQualityScore } from './judge/quality-score.js';
 import type { ObservedApiEndpoint } from './network/traffic-observer.js';
 import type { WorkflowAutomaton, WorkflowAutomatonComparison } from './workflow-automata/types.js';
@@ -195,6 +195,7 @@ export interface RunResult {
   areaResults: AreaResult[];
   unexploredAreas: Array<{ name: string; reason: string }>;
   partial: boolean;
+  partialReason?: RunPartialReason;
   /** Blind spots from coverage tracker. */
   blindSpots: BlindSpot[];
   /** Mermaid graph source for state graph visualization. */
@@ -209,6 +210,8 @@ export interface RunResult {
   crossRunClassification?: CrossRunClassification;
   /** SafetyGuard audit summary for blocked/allowed guarded actions. */
   safetyAudit?: SafetyAuditSummary;
+  /** Approximate LLM/model cost summary for the run. */
+  costSummary?: CostSummary;
   /** Canonical timeline of exploration events for the full run. */
   explorationLedger?: ExplorationLedger;
   /** Experimental workflow automaton mined from observed traces. */
@@ -216,6 +219,11 @@ export interface RunResult {
   /** Comparison summary against prior role/run workflow automata. */
   workflowComparison?: WorkflowAutomatonComparison;
 }
+
+export type RunPartialReason =
+  | 'frontier-remaining'
+  | 'cost-budget-exceeded'
+  | 'time-budget-exceeded';
 
 export type ConfirmationVerdict =
   | 'fixed'
@@ -321,7 +329,12 @@ export interface RunConfigMeta {
   appDescription: string;
   models: { planner: string; worker: string };
   concurrency: number;
-  budget: { timeLimitSeconds: number; maxStepsPerTask: number; maxStateNodes: number };
+  budget: {
+    timeLimitSeconds: number;
+    maxStepsPerTask: number;
+    maxStateNodes: number;
+    costLimitUsd?: number;
+  };
   checkpointInterval: number;
   autoCaptureEnabled: boolean;
   llmPlannerEnabled: boolean;
@@ -467,7 +480,7 @@ export interface ReplayableAction {
 export interface BlindSpot {
   nodeId?: string;
   summary: string;
-  reason: 'blocked' | 'time-budget' | 'pruned' | 'state-unreachable' | 'unknown';
+  reason: 'blocked' | 'time-budget' | 'cost-budget' | 'pruned' | 'state-unreachable' | 'unknown';
   severity: 'low' | 'medium' | 'high';
 }
 
@@ -489,12 +502,7 @@ export interface BudgetConfig {
   maxStepsPerTask: number;
   maxFrontierSize: number;
   maxStateNodes: number;
-  /**
-   * Maximum estimated LLM cost in USD before stopping the run (0 = unlimited).
-   *
-   * Experimental — cost tracking is approximate and based on published per-token rates.
-   * Wire a `CostTracker` from `src/coverage/cost-tracker.ts` into the engine loop to enforce.
-   */
+  /** Maximum approximate model cost in USD before stopping the run (0 = unlimited). */
   costLimitUsd?: number;
 }
 

--- a/src/worker/worker.test.ts
+++ b/src/worker/worker.test.ts
@@ -9,12 +9,61 @@ vi.mock('../llm.js', () => ({
 
 import { executeWorkerTask } from './worker.js';
 import { hasLLMApiKey, judgeObservationWithLLM } from '../llm.js';
+import { CostTracker } from '../coverage/cost-tracker.js';
+import type { ExecuteWorkerTaskOptions } from './worker.js';
+import type { WorkerTask } from '../types.js';
 
 function createMockPage() {
   return {
     url: () => 'https://example.com/manage/knowledge-bases',
     screenshot: vi.fn().mockResolvedValue(Buffer.from('png')),
   };
+}
+
+function createTask(overrides: Partial<WorkerTask> = {}): WorkerTask {
+  return {
+    id: 'task-cost-1',
+    workerType: 'navigation',
+    nodeId: 'node-1',
+    objective: 'Inspect the knowledge bases page',
+    maxSteps: 5,
+    pageType: 'list',
+    missionContext: 'Example app',
+    ...overrides,
+  };
+}
+
+function createOptions(
+  overrides: Partial<ExecuteWorkerTaskOptions> = {}
+): ExecuteWorkerTaskOptions {
+  return {
+    model: 'anthropic/claude-haiku-4-5',
+    screenshotDir: 'C:/tmp/screenshots',
+    agentMode: 'dom',
+    screenshotsEnabled: false,
+    stagnationThreshold: 0,
+    mission: {
+      appDescription: 'Example app',
+      destructiveActionsAllowed: false,
+    },
+    judgeConfig: {
+      enabled: true,
+      requestTimeoutMs: 10_000,
+    },
+    ...overrides,
+  };
+}
+
+function createStagehandReturning(result: unknown) {
+  const page = createMockPage();
+  return {
+    context: {
+      pages: () => [page],
+    },
+    agent: vi.fn(() => ({
+      execute: async () => result,
+    })),
+  } as any;
 }
 
 describe('executeWorkerTask', () => {
@@ -204,5 +253,122 @@ describe('executeWorkerTask', () => {
     expect(result.findings).toHaveLength(1);
     expect(result.findings[0]?.verdict?.hypothesis).toContain('should');
     expect(result.findings[0]?.meta?.source).toBe('agent');
+  });
+
+  it('records Stagehand prompt/completion usage when the result reports camelCase tokens', async () => {
+    const costTracker = new CostTracker();
+    const stagehand = createStagehandReturning({
+      actions: [],
+      usage: {
+        promptTokens: 123,
+        completionTokens: 45,
+      },
+    });
+
+    const result = await executeWorkerTask(
+      stagehand,
+      createTask({ id: 'task-cost-camel' }),
+      createOptions({ costTracker })
+    );
+
+    expect(result.outcome).toBe('completed');
+    expect(costTracker.getRecords()).toEqual([
+      expect.objectContaining({
+        label: 'worker:task-cost-camel:stagehand',
+        inputTokens: 123,
+        outputTokens: 45,
+        source: 'reported',
+      }),
+    ]);
+  });
+
+  it('records Stagehand snake_case usage when providers expose OpenAI-style tokens', async () => {
+    const costTracker = new CostTracker();
+    const stagehand = createStagehandReturning({
+      actions: [],
+      usage: {
+        prompt_tokens: 77,
+        completion_tokens: 11,
+      },
+    });
+
+    await executeWorkerTask(
+      stagehand,
+      createTask({ id: 'task-cost-snake' }),
+      createOptions({ costTracker })
+    );
+
+    expect(costTracker.getRecords()[0]).toEqual(
+      expect.objectContaining({
+        label: 'worker:task-cost-snake:stagehand',
+        inputTokens: 77,
+        outputTokens: 11,
+        source: 'reported',
+      })
+    );
+  });
+
+  it('records Stagehand input/output usage when generic token names are reported', async () => {
+    const costTracker = new CostTracker();
+    const stagehand = createStagehandReturning({
+      actions: [],
+      usage: {
+        inputTokens: 31,
+        outputTokens: 9,
+      },
+    });
+
+    await executeWorkerTask(
+      stagehand,
+      createTask({ id: 'task-cost-generic' }),
+      createOptions({ costTracker })
+    );
+
+    expect(costTracker.getRecords()[0]).toEqual(
+      expect.objectContaining({
+        label: 'worker:task-cost-generic:stagehand',
+        inputTokens: 31,
+        outputTokens: 9,
+        source: 'reported',
+      })
+    );
+  });
+
+  it('falls back to estimated Stagehand usage when no usage object is present', async () => {
+    const costTracker = new CostTracker();
+    const stagehand = createStagehandReturning({ actions: [] });
+
+    await executeWorkerTask(
+      stagehand,
+      createTask({ id: 'task-cost-estimated' }),
+      createOptions({ costTracker })
+    );
+
+    expect(costTracker.getRecords()[0]).toEqual(
+      expect.objectContaining({
+        label: 'worker:task-cost-estimated:stagehand',
+        inputTokens: expect.any(Number),
+        outputTokens: expect.any(Number),
+        source: 'estimated',
+      })
+    );
+  });
+
+  it('does not record Stagehand cost when no tracker is configured', async () => {
+    const stagehand = createStagehandReturning({
+      actions: [],
+      usage: {
+        promptTokens: 123,
+        completionTokens: 45,
+      },
+    });
+
+    const result = await executeWorkerTask(
+      stagehand,
+      createTask({ id: 'task-cost-disabled' }),
+      createOptions()
+    );
+
+    expect(result.outcome).toBe('completed');
   });
 });

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -30,6 +30,7 @@ import { judgeWorkerObservations } from '../judge/judge.js';
 import { hasLLMApiKey, judgeObservationWithLLM } from '../llm.js';
 import { mergeLedgerEntries } from '../ledger.js';
 import type { Blackboard } from '../a2a/blackboard.js';
+import { approximateTokenCount, type CostTracker } from '../coverage/cost-tracker.js';
 
 type StagehandToolSet = NonNullable<Parameters<Stagehand['agent']>[0]>['tools'];
 
@@ -173,6 +174,8 @@ async function materializeObservedFindings(input: {
   actionRecorder: ActionRecorder;
   judgeConfig?: JudgeConfig;
   judgeModel?: string;
+  costTracker?: CostTracker;
+  costLabel?: string;
 }) {
   return judgeWorkerObservations({
     observations: input.observations,
@@ -182,7 +185,10 @@ async function materializeObservedFindings(input: {
     judgeText:
       input.judgeConfig?.enabled !== false && input.judgeModel && hasLLMApiKey(input.judgeModel)
         ? (prompt, timeoutMs) =>
-            judgeObservationWithLLM(input.judgeModel as string, prompt, timeoutMs)
+            judgeObservationWithLLM(input.judgeModel as string, prompt, timeoutMs, {
+              costTracker: input.costTracker,
+              costLabel: input.costLabel ?? 'judge:observation',
+            })
         : undefined,
   });
 }
@@ -201,6 +207,8 @@ async function materializeObservedFindingsSafe(input: {
   actionRecorder: WorkerSetup['actionRecorder'];
   judgeConfig?: JudgeConfig;
   judgeModel?: string;
+  costTracker?: CostTracker;
+  costLabel?: string;
 }): Promise<Awaited<ReturnType<typeof materializeObservedFindings>>> {
   try {
     return await materializeObservedFindings(input);
@@ -220,6 +228,7 @@ async function buildWorkerExecutionResult(input: {
   followupRequests: WorkerSetup['followupRequests'];
   discoveredEdges: WorkerSetup['discoveredEdges'];
   observedApiEndpoints?: ObservedApiEndpoint[];
+  costTracker?: CostTracker;
   stagehandResult?: unknown;
   outcome: WorkerResult['outcome'];
   summary: string;
@@ -230,6 +239,8 @@ async function buildWorkerExecutionResult(input: {
     actionRecorder: input.actionRecorder,
     judgeConfig: input.judgeConfig,
     judgeModel: input.model,
+    costTracker: input.costTracker,
+    costLabel: `worker:${input.task.id}:judge`,
   });
   const stagehandActions = input.stagehandResult
     ? await safeStagehandActions(input.stagehandResult)
@@ -276,6 +287,9 @@ async function runStagehandExecute(input: {
   agent: WorkerSetup['agent'];
   args: StagehandAgentExecuteArgs;
   timeoutMs?: number;
+  model?: string;
+  costTracker?: CostTracker;
+  costLabel?: string;
 }): Promise<StagehandAgentExecuteOutcome> {
   const execute = input.agent.execute as unknown as (
     args: StagehandAgentExecuteArgs
@@ -283,7 +297,9 @@ async function runStagehandExecute(input: {
   const timeoutMs = input.timeoutMs;
   if (!timeoutMs || timeoutMs <= 0) {
     try {
-      return { kind: 'completed', result: await execute(input.args) };
+      const result = await execute(input.args);
+      recordStagehandCost(input, result);
+      return { kind: 'completed', result };
     } catch (error) {
       return { kind: 'error', error };
     }
@@ -291,7 +307,10 @@ async function runStagehandExecute(input: {
 
   const controller = new AbortController();
   const executePromise = execute({ ...input.args, signal: controller.signal }).then(
-    (result) => ({ kind: 'completed' as const, result }),
+    (result) => {
+      recordStagehandCost(input, result);
+      return { kind: 'completed' as const, result };
+    },
     (error) => ({ kind: 'error' as const, error })
   );
 
@@ -310,6 +329,79 @@ async function runStagehandExecute(input: {
   return outcome;
 }
 
+function recordStagehandCost(
+  input: {
+    args: StagehandAgentExecuteArgs;
+    model?: string;
+    costTracker?: CostTracker;
+    costLabel?: string;
+  },
+  result: unknown
+): void {
+  if (!input.model || !input.costTracker) {
+    return;
+  }
+  const usage = extractStagehandUsage(result);
+  let output: string;
+  try {
+    output = typeof result === 'string' ? result : JSON.stringify(result ?? '');
+  } catch {
+    output = '';
+  }
+  input.costTracker.record(
+    input.model,
+    usage?.inputTokens ?? approximateTokenCount(input.args.instruction),
+    usage?.outputTokens ?? approximateTokenCount(output),
+    input.costLabel ?? 'worker:stagehand',
+    { source: usage ? 'reported' : 'estimated' }
+  );
+}
+
+function extractStagehandUsage(
+  result: unknown
+): { inputTokens: number; outputTokens: number } | null {
+  const usage = (
+    result as {
+      usage?: {
+        promptTokens?: unknown;
+        completionTokens?: unknown;
+        prompt_tokens?: unknown;
+        completion_tokens?: unknown;
+        inputTokens?: unknown;
+        outputTokens?: unknown;
+      };
+    }
+  ).usage;
+  if (!usage) {
+    return null;
+  }
+
+  const inputTokens =
+    typeof usage.promptTokens === 'number'
+      ? usage.promptTokens
+      : typeof usage.prompt_tokens === 'number'
+        ? usage.prompt_tokens
+        : typeof usage.inputTokens === 'number'
+          ? usage.inputTokens
+          : undefined;
+  const outputTokens =
+    typeof usage.completionTokens === 'number'
+      ? usage.completionTokens
+      : typeof usage.completion_tokens === 'number'
+        ? usage.completion_tokens
+        : typeof usage.outputTokens === 'number'
+          ? usage.outputTokens
+          : undefined;
+  if (inputTokens === undefined && outputTokens === undefined) {
+    return null;
+  }
+
+  return {
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+  };
+}
+
 export interface ExploreAreaOptions {
   appDescription: string;
   model: string;
@@ -326,6 +418,7 @@ export interface ExploreAreaOptions {
   history?: WorkerHistoryContext;
   judgeConfig?: JudgeConfig;
   safetyGuard?: SafetyGuardLike;
+  costTracker?: CostTracker;
 }
 
 export async function exploreArea(
@@ -349,6 +442,7 @@ export async function exploreArea(
     history,
     judgeConfig,
     safetyGuard,
+    costTracker,
   } = opts;
   // Classify the page and capture fingerprint before starting the worker
   const page = stagehand.context.pages()[0];
@@ -382,11 +476,25 @@ export async function exploreArea(
       safetyGuard,
     });
 
+  const instruction = `Explore the "${area.name}" area of this application. Interact with all visible elements, test forms, check edge cases, and report any issues you find using the log_finding tool. Take screenshots before logging findings and include the evidenceId. Use mark_control_exercised after each interaction to track coverage.`;
+
   try {
     const result = await agent.execute({
-      instruction: `Explore the "${area.name}" area of this application. Interact with all visible elements, test forms, check edge cases, and report any issues you find using the log_finding tool. Take screenshots before logging findings and include the evidenceId. Use mark_control_exercised after each interaction to track coverage.`,
+      instruction,
       maxSteps: stepsPerArea,
     });
+    recordStagehandCost(
+      {
+        args: {
+          instruction,
+          maxSteps: stepsPerArea,
+        },
+        model,
+        costTracker,
+        costLabel: `area:${area.name}:stagehand`,
+      },
+      result
+    );
 
     const stepCount =
       'actions' in result && Array.isArray(result.actions) ? result.actions.length : 0;
@@ -397,6 +505,8 @@ export async function exploreArea(
       actionRecorder,
       judgeConfig,
       judgeModel: model,
+      costTracker,
+      costLabel: `area:${area.name}:judge`,
     });
     const stagehandActions = await safeStagehandActions(result);
     const explorationLedger = mergeLedgerEntries({
@@ -433,6 +543,8 @@ export async function exploreArea(
         actionRecorder,
         judgeConfig,
         judgeModel: model,
+        costTracker,
+        costLabel: `area:${area.name}:judge`,
       });
     } catch {
       // Judge failed to materialize findings; return empty findings array
@@ -483,6 +595,7 @@ export interface ExecuteWorkerTaskOptions {
   judgeConfig?: JudgeConfig;
   visionContext?: string;
   safetyGuard?: SafetyGuardLike;
+  costTracker?: CostTracker;
   /** A2A multi-agent context (optional). */
   a2aContext?: {
     agentRole: AgentRole;
@@ -514,6 +627,7 @@ export async function executeWorkerTask(
     judgeConfig,
     visionContext,
     safetyGuard,
+    costTracker,
     a2aContext,
   } = opts;
   const {
@@ -563,6 +677,9 @@ export async function executeWorkerTask(
         maxSteps: task.maxSteps,
       },
       timeoutMs,
+      model,
+      costTracker,
+      costLabel: `worker:${task.id}:stagehand`,
     });
 
     if (executeOutcome.kind === 'completed') {
@@ -577,6 +694,7 @@ export async function executeWorkerTask(
         followupRequests,
         discoveredEdges,
         observedApiEndpoints,
+        costTracker,
         stagehandResult: executeOutcome.result,
         outcome: 'completed',
         summary: `Completed ${task.workerType} task: ${task.objective}`,
@@ -595,6 +713,7 @@ export async function executeWorkerTask(
         followupRequests,
         discoveredEdges,
         observedApiEndpoints,
+        costTracker,
         outcome: 'timed-out',
         summary: timeoutMs ? `Timed out after ${timeoutMs}ms` : 'Timed out',
       });
@@ -615,6 +734,7 @@ export async function executeWorkerTask(
       followupRequests,
       discoveredEdges,
       observedApiEndpoints,
+      costTracker,
       outcome: 'failed',
       summary: message,
     });
@@ -631,6 +751,7 @@ export async function executeWorkerTask(
       followupRequests,
       discoveredEdges,
       observedApiEndpoints,
+      costTracker,
       outcome: 'failed',
       summary: message,
     });


### PR DESCRIPTION
## Summary

This is the first implementation slice for #183 / #133: make the existing `CostTracker` participate in real runs.

- records model usage for planner, judge, vision, worker, and Stagehand execution paths
- normalizes provider-reported usage for Anthropic, OpenAI-compatible providers, and Google, with deterministic estimates as fallback
- tracks cache token metadata and Anthropic cache-specific pricing
- stops dequeueing new frontier work once the configured cost budget is exceeded
- surfaces partial run reason and cost summaries in JSON/Markdown reports
- appends cost records into the exploration ledger

## Reviewer pass

I reviewed the final diff for the main risks from the earlier local assessment:

- avoided changing `sendChatCompletion()` return shape in this slice to reduce migration risk
- added provider-reported usage extraction instead of relying only on approximate token counts
- added `source: reported | estimated` so reports/ledger do not imply precise billing for fallback estimates
- added `partialReason: cost-budget-exceeded` and cost-budget blind spots for budget-stopped runs
- kept Stagehand usage tolerant of multiple possible usage field shapes

No blocking issues found in the pass. Remaining precision risk is called out below.

## Validation

- `pnpm run build`
- `pnpm run lint` — passes with existing complexity warnings
- `pnpm run test -- --run --coverage=false` — 141 files / 1320 tests passed
- Additional targeted tests during development:
  - `src/coverage/cost-tracker.test.ts`
  - `src/llm/client.test.ts`
  - `src/engine/main-loop.test.ts`
  - `src/llm.test.ts`
  - `src/worker/worker.test.ts`

## Notes / follow-ups

This is intentionally not the full #183 scope. Follow-up slices should add `--estimate-only`, cheap preset, prompt-cache request markers, README guidance, SARIF cost properties, and optional auto-downshift.

Cost values are still approximate when providers omit usage or when Stagehand result usage shape differs from the tolerated shapes; such records are marked `source: estimated`.
