### PR TITLE
[codex] Harden action comments and summaries

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,13 @@ inputs:
     description: 'Post a summary comment on the PR'
     required: false
     default: 'true'
+  comment-key:
+    description: >
+      Optional suffix for the sticky PR comment marker. Set this when running
+      multiple Dramaturge jobs in a matrix so comments do not overwrite each
+      other. Use letters, numbers, dots, underscores, or hyphens.
+    required: false
+    default: ''
   report-dir:
     description: 'Directory for report output (overrides config value)'
     required: false
@@ -99,7 +106,16 @@ runs:
 
     - name: Install Dramaturge
       shell: bash
-      run: npm install -g dramaturge@${{ inputs.dramaturge-version }}
+      env:
+        DRAMATURGE_VERSION: ${{ inputs.dramaturge-version }}
+      run: |
+        case "$DRAMATURGE_VERSION" in
+          ''|*[!A-Za-z0-9._+~-]*)
+            echo "::error::Invalid dramaturge-version input"
+            exit 1
+            ;;
+        esac
+        npm install -g "dramaturge@${DRAMATURGE_VERSION}"
 
     - name: Install Playwright browsers
       shell: bash
@@ -155,17 +171,28 @@ runs:
     - name: Post PR comment
       if: always() && inputs.post-comment == 'true' && github.event_name == 'pull_request' && steps.config.outputs.json-output-enabled == 'true' && steps.parse.outcome == 'success'
       uses: actions/github-script@v7
+      env:
+        SUMMARY_PATH: ${{ steps.parse.outputs.summary-path }}
+        COMMENT_KEY: ${{ inputs.comment-key }}
       with:
         script: |
           const fs = require('fs');
-          const summaryPath = '${{ steps.parse.outputs.summary-path }}';
+          const summaryPath = process.env.SUMMARY_PATH || '';
           if (!summaryPath || !fs.existsSync(summaryPath)) {
             core.info('No summary file found, skipping PR comment');
             return;
           }
           const summary = fs.readFileSync(summaryPath, 'utf-8');
 
-          const marker = '<!-- dramaturge-report -->';
+          const commentKey = process.env.COMMENT_KEY || '';
+          if (!/^[A-Za-z0-9._-]*$/.test(commentKey)) {
+            core.setFailed('Invalid comment-key input. Use only letters, numbers, dots, underscores, or hyphens.');
+            return;
+          }
+
+          const marker = commentKey
+            ? `<!-- dramaturge-report:${commentKey} -->`
+            : '<!-- dramaturge-report -->';
           const body = marker + '\n' + summary;
 
           // Paginate through all comments to find an existing marker

--- a/action.yml
+++ b/action.yml
@@ -110,7 +110,7 @@ runs:
         DRAMATURGE_VERSION: ${{ inputs.dramaturge-version }}
       run: |
         case "$DRAMATURGE_VERSION" in
-          ''|*[!A-Za-z0-9._+~-]*)
+          ''|*[!A-Za-z0-9._+~^-]*)
             echo "::error::Invalid dramaturge-version input"
             exit 1
             ;;

--- a/action/parse-results.js
+++ b/action/parse-results.js
@@ -168,6 +168,12 @@ function setOutput(name, value) {
   }
 }
 
+export function writeStepSummary(markdown, stepSummaryPath = process.env.GITHUB_STEP_SUMMARY) {
+  if (stepSummaryPath) {
+    appendFileSync(stepSummaryPath, markdown, 'utf-8');
+  }
+}
+
 function main() {
   const reportBaseDir = process.argv[2];
   const failOnSeverity = process.argv[3] || '';
@@ -195,6 +201,7 @@ function main() {
   // Write the PR-comment markdown next to the report
   const summaryPath = join(reportDir, 'pr-comment.md');
   writeFileSync(summaryPath, markdown, 'utf-8');
+  writeStepSummary(markdown);
 
   // Check severity threshold
   const exceeded = checkSeverityThreshold(maxSeverity, failOnSeverity);

--- a/src/action/parse-results.test.ts
+++ b/src/action/parse-results.test.ts
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 Alex Rambasek
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
@@ -11,6 +11,7 @@ import {
   buildSummary,
   formatDuration,
   checkSeverityThreshold,
+  writeStepSummary,
 } from '../../action/parse-results.js';
 
 describe('parse-results', () => {
@@ -289,6 +290,24 @@ describe('parse-results', () => {
       const result = buildSummary(report);
       expect(result.markdown).toContain('https://example.com/@\u200Bteam?tab=\\[prod\\]');
       expect(result.markdown).toContain('Breaks \\[link\\]\\(x\\) @\u200Bops');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // writeStepSummary
+  // ---------------------------------------------------------------------------
+
+  describe('writeStepSummary', () => {
+    it('appends the generated markdown to the GitHub step summary file', () => {
+      const summaryPath = join(tempDir, 'step-summary.md');
+
+      writeStepSummary('## Dramaturge\n\nNo findings\n', summaryPath);
+
+      expect(readFileSync(summaryPath, 'utf-8')).toBe('## Dramaturge\n\nNo findings\n');
+    });
+
+    it('does nothing when no step summary file is configured', () => {
+      expect(() => writeStepSummary('## Dramaturge\n', '')).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary

Small first slice of #182 that makes the composite GitHub Action safer and more useful as the PR-time product surface.

- validates `dramaturge-version` before passing it to `npm install -g`
- passes the generated summary path through `SUMMARY_PATH` instead of interpolating it into the GitHub Script source
- adds `comment-key` so matrix jobs can keep separate sticky PR comments
- appends the same generated markdown to `$GITHUB_STEP_SUMMARY` for non-PR / run-page visibility

## Why

The Action is where most CI users will experience Dramaturge. This keeps existing workflows backward compatible while removing avoidable input-interpolation risk and addressing the sticky-comment collision gap called out in #182.

## Validation

- `pnpm run test -- --run src/action/parse-results.test.ts src/action/prepare-config.test.ts --coverage=false`
- `pnpm run lint` (passes with existing warnings)
- `pnpm run build`
- `pnpm test`
- `git diff --check`
- YAML parse smoke test for `action.yml`

## Notes

This intentionally does not move the PR comment renderer into a template module yet; that is a larger #182 follow-up.

Closes part of #182.