### PR TITLE
feat: add diff-scoped QA quality gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20-brightgreen)](https://nodejs.org)
 
-**Autonomous QA testing for web applications.** Point Dramaturge at your app and it will explore, test, and report issues—no test scripts required.
+**The autonomous QA engineer for web applications.** Dramaturge explores your app across
+functional behavior, accessibility, APIs, visual regressions, and opt-in security testing. It
+returns evidence-backed findings that can be replayed, confirmed, and promoted into durable tests.
 
 ## Quick Start
 
@@ -21,15 +23,16 @@ npx dramaturge doctor
 # If you're in CI/Docker (non-interactive) or prompts are disabled, install Chromium manually:
 # npx playwright install chromium
 
-# Generate config
-npx dramaturge auto-config
-
 # Set API key (choose one provider)
 export ANTHROPIC_API_KEY="your-key-here"
 # See LLM Providers section for other options
 
-# Run
-npx dramaturge --config dramaturge.config.json
+# Run immediately—no config file required
+npx dramaturge run https://your-app.example.com --preset smoke
+
+# Or generate a framework-aware project config
+npx dramaturge auto-config
+npx dramaturge run --config dramaturge.config.json
 ```
 
 ## What It Does
@@ -42,9 +45,11 @@ Dramaturge uses LLM-driven browser agents to autonomously test web applications:
 - **Tests APIs** — Validates contracts, auth boundaries, error responses
 - **Security testing** — OWASP scenarios, injection attacks (opt-in)
 - **Visual regression** — Pixel-diff comparison (opt-in)
-- **Provides evidence** — Screenshots, reproduction steps, network traces
+- **Validates findings** — Evidence chains, replayable actions, screenshots, and optional live replay
+- **Builds regressions** — Promotes strong findings into maintainable Playwright specs
 
-No test scripts. No brittle selectors. Works with any web framework.
+It is a full pre-production quality loop—not a pentesting-only tool. Repository adaptation detects
+framework conventions for Next.js, Django, Rails, Express, and other common stacks.
 
 ## Configuration
 
@@ -102,6 +107,31 @@ Available presets:
 
 The same presets are available to the inline CLI: `dramaturge run <url> --preset smoke`.
 
+### Diff-scoped runs
+
+Restrict a run to routes and API surfaces affected by a branch diff:
+
+```bash
+npx dramaturge run --config dramaturge.config.json \
+  --scope-mode diff --diff-base origin/main
+```
+
+`--diff origin/main` remains available as a shorthand. If changed files cannot be mapped to a
+route, Dramaturge falls back safely instead of pruning the entire run. The GitHub Action uses diff
+scope automatically for pull requests; set `scope-mode: all` to opt out.
+
+### Remembered CLI preferences
+
+Explicit, non-secret run preferences such as `--preset`, `--provider`, `--headless`, output formats,
+diff scope, and the quality-gate threshold are saved to `~/.dramaturge/cli-config.json`. API keys,
+target URLs, auth profiles, and credentials are never stored there. Precedence is:
+
+```text
+explicit CLI flags > project config > saved user preferences > built-in defaults
+```
+
+Project config therefore remains authoritative for shared repository behavior.
+
 ## LLM Providers
 
 Dramaturge supports multiple providers via model-string prefixes (e.g., `anthropic/claude-sonnet-4-6`). Omitting the prefix defaults to Anthropic.
@@ -123,7 +153,8 @@ Dramaturge supports multiple providers via model-string prefixes (e.g., `anthrop
 
 ## Confirming Fixes
 
-After fixing a bug, replay saved actions to verify:
+Every report keeps the evidence and replay actions behind its findings. After fixing a bug, replay
+those actions to verify the outcome instead of relying on a pattern match alone:
 
 ```bash
 # Confirm one finding from latest report
@@ -137,6 +168,17 @@ npx dramaturge confirm --all
 ```
 
 **Exit codes:** `0` = all fixed, `1` = issues remain, `2` = cannot confirm, `3` = needs review.
+
+For the main `run` command, the default quality gate fails on `major` or `critical` findings:
+
+```bash
+npx dramaturge run https://your-app.example.com --fail-on-severity critical
+npx dramaturge run https://your-app.example.com --fail-on-severity none
+```
+
+`run` returns `0` when the gate passes, `1` for an execution/configuration error, and `2` when the
+finding threshold is met. Configure the project default with
+`"qualityGate": { "failOnSeverity": "minor" }`.
 
 ## Building Regression Tests
 
@@ -155,6 +197,14 @@ npx dramaturge regress promote BUG-0042
 
 Quality scores consider URL context, actions, evidence, screenshots, and confidence. Only findings with replay actions and clear expected/actual differences are promotable.
 
+## Collaborative agents
+
+Optional A2A mode coordinates five specialists around a shared blackboard: the **Scout** maps the
+surface, the **Tester** exercises workflows, the **Security** agent probes safe adversarial cases,
+the **Reviewer** redirects work toward suspicious behavior, and the **Reporter** synthesizes the
+evidence. Together they behave like a QA team sharing discoveries—not isolated scanners producing
+five disconnected reports. See [A2A Multi-Agent Mode](./docs/a2a-mode.md).
+
 ## CI/CD Integration
 
 Add to `.github/workflows/qa.yml`:
@@ -165,6 +215,7 @@ Add to `.github/workflows/qa.yml`:
     config: dramaturge.config.json
     anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
     fail-on-severity: major
+    scope-mode: auto # diff-scoped for pull requests
 ```
 
 See [GitHub Action Reference](#github-action-reference) for all options.
@@ -239,7 +290,23 @@ See [GitHub Action Reference](#github-action-reference) for all options.
 }
 ```
 
-Formats: `"markdown"`, `"json"`, or `"both"`
+Formats: `"markdown"`, `"json"`, `"junit"`, `"sarif"`, or `"both"`.
+
+### Quality gate and diff scope
+
+```json
+{
+  "qualityGate": { "failOnSeverity": "major" },
+  "diffAware": {
+    "enabled": true,
+    "baseRef": "origin/main",
+    "restrictToChanged": true
+  }
+}
+```
+
+Quality-gate values are `critical`, `major`, `minor`, `trivial`, and `none`. CLI flags override
+these project settings for one run.
 
 ### Optional Features
 
@@ -409,6 +476,8 @@ Test public-facing pages without authentication.
 | `openai-api-key` | OpenAI API key | — |
 | `google-api-key` | Google Generative AI API key | — |
 | `fail-on-severity` | Fail if findings ≥ severity | — |
+| `scope-mode` | `auto` (PR diff), `diff`, or `all` | `auto` |
+| `diff-base` | Base ref for explicit diff scope | PR base branch |
 | `post-comment` | Post PR comment | `true` |
 | `upload-report` | Upload as artifact | `true` |
 
@@ -428,6 +497,7 @@ Test public-facing pages without authentication.
     config: dramaturge.config.json
     anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
     fail-on-severity: major
+    scope-mode: auto
     post-comment: true
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,19 @@ inputs:
   fail-on-severity:
     description: >
       Fail the step if findings at or above this severity are found.
-      Accepted values: critical, major, minor, trivial.
+      Accepted values: critical, major, minor, trivial, none.
       Leave empty to never fail on findings.
+    required: false
+    default: ''
+  scope-mode:
+    description: >
+      Exploration scope: auto scopes pull requests to their diff, diff always uses
+      diff-base, and all scans the full application. Auto preserves project config
+      outside pull requests.
+    required: false
+    default: 'auto'
+  diff-base:
+    description: 'Git ref used for diff scope. In pull requests, defaults to the base branch.'
     required: false
     default: ''
   upload-report:
@@ -115,7 +126,45 @@ runs:
         INPUT_REPORT_DIR: ${{ inputs.report-dir }}
         INPUT_FORCE_JSON_OUTPUT: ${{ inputs.force-json-output }}
         INPUT_FORCE_HEADLESS: ${{ inputs.force-headless }}
+        INPUT_FAIL_ON_SEVERITY: ${{ inputs.fail-on-severity }}
       run: node "${{ github.action_path }}/action/prepare-config.js"
+
+    - name: Resolve exploration scope
+      id: scope
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        INPUT_SCOPE_MODE: ${{ inputs.scope-mode }}
+        INPUT_DIFF_BASE: ${{ inputs.diff-base }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_REF: ${{ github.base_ref }}
+      run: |
+        mode="${INPUT_SCOPE_MODE,,}"
+        base="$INPUT_DIFF_BASE"
+
+        if [[ "$mode" == "auto" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            mode="diff"
+            if [[ -z "$base" && -n "$BASE_REF" ]]; then
+              git fetch --no-tags --depth=1 origin "$BASE_REF"
+              base="FETCH_HEAD"
+            fi
+          else
+            mode=""
+          fi
+        fi
+
+        if [[ "$mode" != "" && "$mode" != "all" && "$mode" != "diff" ]]; then
+          echo "::error::scope-mode must be auto, all, or diff"
+          exit 1
+        fi
+        if [[ "$mode" == "diff" && -z "$base" ]]; then
+          echo "::error::diff scope requires diff-base outside a pull request"
+          exit 1
+        fi
+
+        echo "mode=$mode" >> "$GITHUB_OUTPUT"
+        echo "base=$base" >> "$GITHUB_OUTPUT"
 
     - name: Run Dramaturge
       id: run
@@ -125,7 +174,17 @@ runs:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
         OPENAI_API_KEY: ${{ inputs.openai-api-key }}
         GOOGLE_GENERATIVE_AI_API_KEY: ${{ inputs.google-api-key }}
-      run: dramaturge --config "${{ steps.config.outputs.config-path }}"
+        SCOPE_MODE: ${{ steps.scope.outputs.mode }}
+        DIFF_BASE: ${{ steps.scope.outputs.base }}
+      run: |
+        args=(--config "${{ steps.config.outputs.config-path }}")
+        if [[ -n "$SCOPE_MODE" ]]; then
+          args+=(--scope-mode "$SCOPE_MODE")
+        fi
+        if [[ "$SCOPE_MODE" == "diff" ]]; then
+          args+=(--diff-base "$DIFF_BASE")
+        fi
+        dramaturge "${args[@]}"
       continue-on-error: true
 
     - name: Parse results

--- a/action.yml
+++ b/action.yml
@@ -162,6 +162,32 @@ runs:
           echo "::error::diff scope requires diff-base outside a pull request"
           exit 1
         fi
+        if [[ "$mode" == "diff" ]]; then
+          if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+            fetch_ref="$base"
+            if [[ "$fetch_ref" == refs/remotes/origin/* ]]; then
+              fetch_ref="${fetch_ref#refs/remotes/origin/}"
+            elif [[ "$fetch_ref" == origin/* ]]; then
+              fetch_ref="${fetch_ref#origin/}"
+            elif [[ "$fetch_ref" == refs/heads/* ]]; then
+              fetch_ref="${fetch_ref#refs/heads/}"
+            fi
+
+            if ! git fetch --no-tags --depth=1 origin "$fetch_ref"; then
+              echo "::error::Unable to fetch diff-base '$base'"
+              exit 1
+            fi
+
+            if git rev-parse --verify --quiet "${base}^{commit}" >/dev/null; then
+              :
+            elif git rev-parse --verify --quiet "FETCH_HEAD^{commit}" >/dev/null; then
+              base="FETCH_HEAD"
+            else
+              echo "::error::Unable to resolve diff-base '$base' to a commit"
+              exit 1
+            fi
+          fi
+        fi
 
         echo "mode=$mode" >> "$GITHUB_OUTPUT"
         echo "base=$base" >> "$GITHUB_OUTPUT"

--- a/action/parse-results.js
+++ b/action/parse-results.js
@@ -109,7 +109,7 @@ export function buildSummary(report) {
 
   const duration = meta.durationMs ? formatDuration(meta.durationMs) : 'unknown';
 
-  let md = `## \u{1F3AD} Dramaturge QA Report\n\n`;
+  let md = `## \u{1F3AD} Dramaturge Evidence-Backed QA Report\n\n`;
   md += `**Target:** ${escapeMarkdownInline(meta.targetUrl || 'unknown')}  \n`;
   md += `**Duration:** ${duration}  \n`;
 

--- a/action/prepare-config.js
+++ b/action/prepare-config.js
@@ -14,6 +14,7 @@
  *   INPUT_REPORT_DIR  – report directory override
  *   INPUT_FORCE_JSON_OUTPUT – whether to ensure JSON output is enabled
  *   INPUT_FORCE_HEADLESS – whether to force browser.headless=true
+ *   INPUT_FAIL_ON_SEVERITY – quality-gate threshold (empty means none)
  *   GITHUB_OUTPUT     – GitHub Actions output file
  */
 
@@ -47,12 +48,19 @@ export function parseBooleanInput(value, defaultValue) {
  *   reportDir?: string,
  *   forceJsonOutput?: boolean,
  *   forceHeadless?: boolean,
+ *   failOnSeverity?: string,
  * }} [options]
  * @returns {Record<string, any>}
  */
 export function applyActionOverrides(
   config,
-  { targetUrl = '', reportDir = '', forceJsonOutput = true, forceHeadless = true } = {}
+  {
+    targetUrl = '',
+    reportDir = '',
+    forceJsonOutput = true,
+    forceHeadless = true,
+    failOnSeverity = 'none',
+  } = {}
 ) {
   const nextConfig = { ...config };
 
@@ -89,6 +97,16 @@ export function applyActionOverrides(
     nextConfig.browser.headless = true;
   }
 
+  const normalizedThreshold = failOnSeverity.trim().toLowerCase() || 'none';
+  const validThresholds = ['critical', 'major', 'minor', 'trivial', 'none'];
+  if (!validThresholds.includes(normalizedThreshold)) {
+    throw new Error(
+      `Invalid fail-on-severity value: ${failOnSeverity}. Expected one of: ${validThresholds.join(', ')}`
+    );
+  }
+  nextConfig.qualityGate = { ...(config.qualityGate || {}) };
+  nextConfig.qualityGate.failOnSeverity = normalizedThreshold;
+
   return nextConfig;
 }
 
@@ -116,6 +134,7 @@ export function isJsonOutputEnabled(config) {
  *   reportDir?: string,
  *   forceJsonOutput?: boolean,
  *   forceHeadless?: boolean,
+ *   failOnSeverity?: string,
  *   githubOutput?: string,
  * }} [options]
  * @returns {{
@@ -131,6 +150,7 @@ export function prepareConfig({
   reportDir = '',
   forceJsonOutput = true,
   forceHeadless = true,
+  failOnSeverity = 'none',
   githubOutput = '',
 } = {}) {
   let config = {};
@@ -146,6 +166,7 @@ export function prepareConfig({
     reportDir,
     forceJsonOutput,
     forceHeadless,
+    failOnSeverity,
   });
 
   const configDir = dirname(resolvedConfigPath);
@@ -181,6 +202,7 @@ function main() {
     reportDir: process.env.INPUT_REPORT_DIR || '',
     forceJsonOutput: parseBooleanInput(process.env.INPUT_FORCE_JSON_OUTPUT, true),
     forceHeadless: parseBooleanInput(process.env.INPUT_FORCE_HEADLESS, true),
+    failOnSeverity: process.env.INPUT_FAIL_ON_SEVERITY || 'none',
     githubOutput: process.env.GITHUB_OUTPUT || '',
   });
 

--- a/docs/a2a-mode.md
+++ b/docs/a2a-mode.md
@@ -1,6 +1,20 @@
 # A2A Multi-Agent Mode
 
-Dramaturge supports an optional **A2A (Agent-to-Agent) multi-agent coordination mode** based on Google's A2A protocol. When enabled, the engine routes tasks to specialized agents with distinct roles, enabling coordinated exploration and testing workflows.
+Dramaturge supports an optional **A2A (Agent-to-Agent) multi-agent coordination mode** based on Google's A2A protocol. Think of it as an autonomous QA team: specialists divide the work, publish discoveries to shared memory, and use each other's evidence to pursue deeper checks.
+
+```mermaid
+flowchart LR
+  C[Coordinator] --> S[Scout]
+  C --> T[Tester]
+  C --> X[Security]
+  S --> B[(Shared blackboard)]
+  T --> B
+  X --> B
+  B --> R[Reviewer]
+  R -->|redirects and follow-ups| C
+  B --> P[Reporter]
+  P --> O[One evidence-backed report]
+```
 
 ## Agent Roles
 
@@ -10,7 +24,7 @@ A2A mode includes five specialized agent roles:
 - **Tester** (`agent-tester`): Deep-dives into forms, CRUD flows, and API endpoints with domain-specific reasoning
 - **Security** (`agent-security`): Runs adversarial scenarios with security-domain knowledge (OWASP patterns, boundary probing)
 - **Reviewer** (`agent-reviewer`): Observes other agents in real-time and redirects them toward suspicious behaviors
-- **Reporter** (`agent-reporter`): Synthesizes findings across all agents into coherent narratives
+- **Reporter** (`agent-reporter`): Synthesizes findings and evidence across all agents into one coherent report
 
 ## Configuration
 
@@ -95,6 +109,7 @@ When A2A is enabled, workers receive additional context:
 - **Specialized reasoning**: Each agent applies domain-specific knowledge (navigation patterns, form validation heuristics, security threat models)
 - **Coordinated coverage**: Agents avoid duplicate work by observing the blackboard
 - **Dynamic prioritization**: Reviewer can redirect agents based on emerging patterns
+- **Chained discoveries**: A route found by the Scout can become a workflow test, an authorization probe, and a Reviewer-directed follow-up
 - **Comprehensive narratives**: Reporter synthesizes findings across multiple testing perspectives
 
 ## When to Use A2A

--- a/dramaturge.config.example.json
+++ b/dramaturge.config.example.json
@@ -143,6 +143,12 @@
     "screenshots": true
   },
 
+  // `dramaturge run` exits with code 2 when a deduplicated finding meets this
+  // threshold. Use "none" to report findings without failing the command.
+  "qualityGate": {
+    "failOnSeverity": "major"
+  },
+
   "memory": {
     "enabled": true,
     "dir": "./.dramaturge",

--- a/dramaturge.config.minimal.json
+++ b/dramaturge.config.minimal.json
@@ -18,6 +18,10 @@
     "screenshots": true
   },
 
+  "qualityGate": {
+    "failOnSeverity": "major"
+  },
+
   "browser": {
     "headless": false
   }

--- a/src/action/prepare-config.test.ts
+++ b/src/action/prepare-config.test.ts
@@ -70,6 +70,7 @@ describe('prepare-config', () => {
         targetUrl: 'https://input.example.com',
         output: { format: 'both', dir: './ci-reports' },
         browser: { headless: true },
+        qualityGate: { failOnSeverity: 'none' },
       });
     });
 
@@ -88,7 +89,17 @@ describe('prepare-config', () => {
       expect(prepared).toEqual({
         output: { format: 'markdown', dir: './reports' },
         browser: { headless: false },
+        qualityGate: { failOnSeverity: 'none' },
       });
+    });
+
+    it('configures and validates the run quality gate', () => {
+      expect(applyActionOverrides({}, { failOnSeverity: 'MAJOR' }).qualityGate.failOnSeverity).toBe(
+        'major'
+      );
+      expect(() => applyActionOverrides({}, { failOnSeverity: 'urgent' })).toThrow(
+        'Invalid fail-on-severity value'
+      );
     });
   });
 

--- a/src/cli-preferences.test.ts
+++ b/src/cli-preferences.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getCliPreferencesPath,
+  loadCliPreferences,
+  saveCliPreferences,
+} from './cli-preferences.js';
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dramaturge-cli-preferences-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('CLI preferences', () => {
+  it('uses the documented path beneath the home directory', () => {
+    expect(getCliPreferencesPath('C:/Users/tester')).toBe(
+      join('C:/Users/tester', '.dramaturge', 'cli-config.json')
+    );
+  });
+
+  it('returns empty versioned preferences when the file is absent or invalid', () => {
+    const dir = createTempDir();
+    const path = join(dir, 'cli-config.json');
+    expect(loadCliPreferences(path)).toEqual({ version: 1 });
+    writeFileSync(path, '{invalid', 'utf-8');
+    expect(loadCliPreferences(path)).toEqual({ version: 1 });
+  });
+
+  it('round-trips only schema-approved non-secret preferences', () => {
+    const dir = createTempDir();
+    const path = join(dir, 'nested', 'cli-config.json');
+    saveCliPreferences(
+      {
+        provider: 'openai',
+        preset: 'smoke',
+        focusModes: ['navigation', 'api'],
+        formats: ['markdown', 'sarif'],
+        headless: true,
+        scopeMode: 'diff',
+        diffBase: 'origin/main',
+        failOnSeverity: 'major',
+      },
+      path
+    );
+
+    expect(loadCliPreferences(path)).toMatchObject({
+      version: 1,
+      provider: 'openai',
+      preset: 'smoke',
+      scopeMode: 'diff',
+      failOnSeverity: 'major',
+    });
+    expect(readFileSync(path, 'utf-8')).not.toContain('API_KEY');
+  });
+
+  it('rejects unknown fields instead of persisting arbitrary data', () => {
+    const dir = createTempDir();
+    const path = join(dir, 'cli-config.json');
+    expect(() =>
+      saveCliPreferences({ targetUrl: 'https://private.example.com' } as never, path)
+    ).toThrow();
+  });
+});

--- a/src/cli-preferences.ts
+++ b/src/cli-preferences.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { z } from 'zod';
+import { writeFileAtomic } from './utils/atomic-file.js';
+import { FAILURE_SEVERITIES } from './severity.js';
+import { FOCUS_MODES } from './config-inline.js';
+import { PRESET_NAMES } from './presets.js';
+
+const ProviderSchema = z.enum(['anthropic', 'openai', 'google', 'azure', 'openrouter', 'github']);
+const OutputFormatSchema = z.enum(['markdown', 'json', 'both', 'junit', 'sarif']);
+
+const CliPreferencesSchema = z
+  .object({
+    version: z.literal(1).default(1),
+    provider: ProviderSchema.optional(),
+    preset: z.enum(PRESET_NAMES).optional(),
+    focusModes: z.array(z.enum(FOCUS_MODES)).optional(),
+    formats: z.array(OutputFormatSchema).min(1).optional(),
+    headless: z.boolean().optional(),
+    scopeMode: z.enum(['all', 'diff']).optional(),
+    diffBase: z.string().min(1).optional(),
+    failOnSeverity: z.enum(FAILURE_SEVERITIES).optional(),
+  })
+  .strict();
+
+export type CliPreferences = z.infer<typeof CliPreferencesSchema>;
+
+export function getCliPreferencesPath(homeDir = homedir()): string {
+  return join(homeDir, '.dramaturge', 'cli-config.json');
+}
+
+export function loadCliPreferences(path = getCliPreferencesPath()): CliPreferences {
+  if (!existsSync(path)) return { version: 1 };
+  try {
+    return CliPreferencesSchema.parse(JSON.parse(readFileSync(path, 'utf-8')));
+  } catch {
+    return { version: 1 };
+  }
+}
+
+export function saveCliPreferences(
+  preferences: Omit<CliPreferences, 'version'>,
+  path = getCliPreferencesPath()
+): void {
+  const validated = CliPreferencesSchema.parse({ version: 1, ...preferences });
+  writeFileAtomic(path, `${JSON.stringify(validated, null, 2)}\n`);
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -57,7 +57,34 @@ describe('parseCliArgs', () => {
   it('parses --diff flag', () => {
     const result = parseCliArgs(['--diff', 'origin/main']);
     expect(result.diffRef).toBe('origin/main');
+    expect(result.scopeMode).toBe('diff');
+    expect(result.diffBase).toBe('origin/main');
     expect(result.showHelp).toBe(false);
+  });
+
+  it('parses first-class diff scope and quality-gate flags', () => {
+    const result = parseCliArgs([
+      'run',
+      '--scope-mode',
+      'diff',
+      '--diff-base',
+      'main',
+      '--fail-on-severity',
+      'Minor',
+    ]);
+    expect(result.scopeMode).toBe('diff');
+    expect(result.diffBase).toBe('main');
+    expect(result.failOnSeverity).toBe('minor');
+  });
+
+  it('rejects contradictory and invalid scope flags', () => {
+    expect(() => parseCliArgs(['--scope-mode', 'all', '--diff-base', 'main'])).toThrow(
+      'cannot be combined'
+    );
+    expect(() => parseCliArgs(['--scope-mode', 'changed'])).toThrow('Invalid scope mode');
+    expect(() => parseCliArgs(['--fail-on-severity', 'urgent'])).toThrow(
+      'Invalid failure severity'
+    );
   });
 
   it('parses --diff alongside other flags', () => {
@@ -495,6 +522,38 @@ describe('runCli', () => {
     expect(passedConfig.auth.type).toBe('none');
   });
 
+  it('turns first-class diff flags into a restricted engine run', async () => {
+    const runEngineMock = vi.fn().mockResolvedValue(undefined);
+
+    const exitCode = await runCli(
+      [
+        'run',
+        'https://example.com',
+        '--scope-mode',
+        'diff',
+        '--diff-base',
+        'origin/main',
+        '--fail-on-severity',
+        'none',
+      ],
+      {
+        loadConfig: vi.fn(),
+        runEngine: runEngineMock,
+        log: vi.fn(),
+        error: vi.fn(),
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    const [passedConfig, passedOptions] = runEngineMock.mock.calls[0];
+    expect(passedConfig.diffAware).toMatchObject({
+      enabled: true,
+      baseRef: 'origin/main',
+      restrictToChanged: true,
+    });
+    expect(passedOptions.diffRef).toBe('origin/main');
+  });
+
   it('builds config with login flag', async () => {
     const runEngineMock = vi.fn().mockResolvedValue(undefined);
 
@@ -508,6 +567,98 @@ describe('runCli', () => {
     expect(exitCode).toBe(0);
     const passedConfig = runEngineMock.mock.calls[0][0];
     expect(passedConfig.auth.type).toBe('interactive');
+  });
+
+  it('uses stored preferences for inline runs and saves explicit overrides', async () => {
+    const runEngineMock = vi.fn().mockResolvedValue(undefined);
+    const saveCliPreferences = vi.fn();
+
+    await runCli(['run', 'https://example.com', '--provider', 'openai'], {
+      loadConfig: vi.fn(),
+      runEngine: runEngineMock,
+      loadCliPreferences: () => ({ version: 1, preset: 'smoke', headless: true }),
+      saveCliPreferences,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+
+    const passedConfig = runEngineMock.mock.calls[0][0];
+    expect(passedConfig.browser.headless).toBe(true);
+    expect(passedConfig.models.planner).toBe('openai/gpt-4.1');
+    expect(passedConfig.budget.globalTimeLimitSeconds).toBe(180);
+    expect(saveCliPreferences).toHaveBeenCalledWith({
+      preset: 'smoke',
+      headless: true,
+      provider: 'openai',
+    });
+  });
+
+  it('layers stored defaults below project config and explicit CLI flags above it', async () => {
+    const config = {
+      targetUrl: 'https://example.com',
+      diffAware: { enabled: false, restrictToChanged: false },
+      qualityGate: { failOnSeverity: 'none' },
+      _meta: { configDir: resolve('C:/tmp') },
+    } as never;
+    const loadConfig = vi.fn().mockReturnValue(config);
+
+    await runCli(['run', '--config', 'c.json', '--headless'], {
+      loadConfig,
+      runEngine: vi.fn().mockResolvedValue(undefined),
+      loadCliPreferences: () => ({ version: 1, preset: 'smoke' }),
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+
+    expect(loadConfig).toHaveBeenCalledWith('c.json', {
+      defaults: { preset: 'smoke' },
+      overrides: { browser: { headless: true } },
+    });
+  });
+
+  it('returns exit code 2 when a completed run exceeds the finding threshold', async () => {
+    const errors: string[] = [];
+    const runEngineMock = vi.fn().mockImplementation(async (_config, options) => {
+      options.eventStream.emit('run:end', {
+        timestamp: '2026-08-28T00:00:00.000Z',
+        tasksExecuted: 1,
+        totalFindings: 2,
+        findingsBySeverity: { Critical: 0, Major: 1, Minor: 1, Trivial: 0 },
+        statesDiscovered: 1,
+        blindSpots: 0,
+        durationMs: 10,
+      });
+    });
+
+    const exitCode = await runCli(['run', 'https://example.com', '--fail-on-severity', 'major'], {
+      loadConfig: vi.fn(),
+      runEngine: runEngineMock,
+      log: vi.fn(),
+      error: (message) => errors.push(message),
+    });
+
+    expect(exitCode).toBe(2);
+    expect(errors.join('\n')).toContain('Quality gate failed');
+  });
+
+  it('allows findings when the quality gate is disabled', async () => {
+    const runEngineMock = vi.fn().mockImplementation(async (_config, options) => {
+      options.eventStream.emit('finding', {
+        taskId: 'task-1',
+        title: 'Broken checkout',
+        severity: 'Critical',
+        category: 'Bug',
+      });
+    });
+
+    const exitCode = await runCli(['run', 'https://example.com', '--fail-on-severity', 'none'], {
+      loadConfig: vi.fn(),
+      runEngine: runEngineMock,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+
+    expect(exitCode).toBe(0);
   });
 
   it('reports errors and returns a failing exit code', async () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,12 @@
 
 import { pathToFileURL } from 'node:url';
 import yargs from 'yargs';
-import { loadConfig, type LoadedDramaturgeConfig, type DramaturgeConfig } from './config.js';
+import {
+  loadConfig,
+  type LoadedDramaturgeConfig,
+  type DramaturgeConfig,
+  type LoadConfigOptions,
+} from './config.js';
 import { resolveResumeDir } from './config-paths.js';
 import { runEngine, type RunEngineOptions } from './engine.js';
 import { EngineEventEmitter } from './engine/event-stream.js';
@@ -13,10 +18,18 @@ import {
   buildConfigFromArgs,
   FOCUS_MODES,
   PRESET_NAMES,
+  resolveProviderDefaults,
   type FocusMode,
   type InlineRunArgs,
   type PresetName,
 } from './config-inline.js';
+import { loadCliPreferences, saveCliPreferences, type CliPreferences } from './cli-preferences.js';
+import {
+  FAILURE_SEVERITIES,
+  emptySeverityCounts,
+  meetsSeverityThreshold,
+  type FailureSeverity,
+} from './severity.js';
 import { runDoctor } from './commands/doctor.js';
 import { runInit, type InitTemplate } from './commands/init.js';
 import { runTriageCommand } from './commands/triage.js';
@@ -51,6 +64,12 @@ export interface ParsedCliArgs {
   configPath?: string;
   resumeDir?: string;
   diffRef?: string;
+  /** First-class exploration scope. `diff` restricts traversal to changed areas. */
+  scopeMode?: 'all' | 'diff';
+  /** Git ref used by diff scope mode. */
+  diffBase?: string;
+  /** Finding severity that makes a completed run return exit code 2. */
+  failOnSeverity?: FailureSeverity;
   dashboard: boolean;
   showHelp: boolean;
   /** Positional URL for `run <url>` */
@@ -122,9 +141,11 @@ export interface ParsedCliArgs {
 }
 
 export interface CliDependencies {
-  loadConfig: (configPath?: string) => LoadedDramaturgeConfig;
+  loadConfig: (configPath?: string, options?: LoadConfigOptions) => LoadedDramaturgeConfig;
   runEngine: (config: DramaturgeConfig, options?: RunEngineOptions) => Promise<void>;
   runMcpServer?: () => Promise<void>;
+  loadCliPreferences?: () => CliPreferences;
+  saveCliPreferences?: (preferences: Omit<CliPreferences, 'version'>) => void;
   log: (message: string) => void;
   error: (message: string) => void;
 }
@@ -149,7 +170,10 @@ Commands:
 Run options:
   --config <path>      Path to config file (default: dramaturge.config.json)
   --resume <run-dir>   Resume a previous run from its output directory
-  --diff <base-ref>    Enable diff-aware mode against a git ref (e.g. origin/main)
+  --scope-mode <mode>  Exploration scope: all or diff
+  --diff-base <ref>    Git ref used by --scope-mode diff (e.g. origin/main)
+  --diff <base-ref>    Legacy shorthand for --scope-mode diff --diff-base <ref>
+  --fail-on-severity   Exit 2 for findings at/above: critical, major, minor, trivial, none
   --dashboard          Show a real-time terminal dashboard (powered by Ink)
   --login              Enable interactive auth (opens browser for sign-in)
   --headless           Run browser in headless mode
@@ -231,11 +255,14 @@ Environment variables:
   GOOGLE_GENERATIVE_AI_API_KEY   API key for Google models
 
 Dramaturge auto-loads .env files from the current directory.
+Safe run preferences are saved to ~/.dramaturge/cli-config.json (never API keys or URLs).
 `;
 
 const DEFAULT_CLI_DEPENDENCIES: CliDependencies = {
   loadConfig,
   runEngine,
+  loadCliPreferences,
+  saveCliPreferences,
   log: (message) => {
     console.log(message);
   },
@@ -273,6 +300,9 @@ const VALUE_FLAGS = new Set([
   '--config',
   '--resume',
   '--diff',
+  '--scope-mode',
+  '--diff-base',
+  '--fail-on-severity',
   '--url',
   '--output',
   '--from-report',
@@ -302,6 +332,23 @@ function parsePreset(value: string): ParsedCliArgs['preset'] {
     throw new Error(`Invalid preset: ${value}. Must be one of: ${[...VALID_PRESETS].join(', ')}`);
   }
   return value as ParsedCliArgs['preset'];
+}
+
+function parseScopeMode(value: string): ParsedCliArgs['scopeMode'] {
+  if (value !== 'all' && value !== 'diff') {
+    throw new Error(`Invalid scope mode: ${value}. Must be one of: all, diff`);
+  }
+  return value;
+}
+
+function parseFailureSeverity(value: string): FailureSeverity {
+  const normalized = value.toLowerCase();
+  if (!(FAILURE_SEVERITIES as readonly string[]).includes(normalized)) {
+    throw new Error(
+      `Invalid failure severity: ${value}. Must be one of: ${FAILURE_SEVERITIES.join(', ')}`
+    );
+  }
+  return normalized as FailureSeverity;
 }
 
 function parseTemplate(value: string): InitTemplate {
@@ -435,6 +482,9 @@ function parseWithYargs(args: readonly string[]) {
     .option('config', { type: 'string' })
     .option('resume', { type: 'string' })
     .option('diff', { type: 'string' })
+    .option('scope-mode', { type: 'string', coerce: parseScopeMode })
+    .option('diff-base', { type: 'string' })
+    .option('fail-on-severity', { type: 'string', coerce: parseFailureSeverity })
     .option('dashboard', { type: 'boolean' })
     .option('login', { type: 'boolean' })
     .option('headless', { type: 'boolean' })
@@ -524,16 +574,30 @@ export function parseCliArgs(args: readonly string[]): ParsedCliArgs {
   const initTemplate = argv.template as InitTemplate | undefined;
   const repoPath = argv.repo;
   const noScan = argv.noScan || undefined;
+  const legacyDiff = argv.diff;
+  const diffBase = argv.diffBase ?? legacyDiff;
+  const scopeMode = (argv.scopeMode ?? (legacyDiff || argv.diffBase ? 'diff' : undefined)) as
+    | ParsedCliArgs['scopeMode']
+    | undefined;
 
   if (noScan && repoPath) {
     throw new Error('--no-scan and --repo cannot be used together');
+  }
+  if (legacyDiff && argv.diffBase && legacyDiff !== argv.diffBase) {
+    throw new Error('--diff and --diff-base must name the same ref when used together');
+  }
+  if (scopeMode === 'all' && diffBase) {
+    throw new Error('--diff/--diff-base cannot be combined with --scope-mode all');
   }
 
   return {
     command: positionalArgs.command,
     configPath: argv.config,
     resumeDir: argv.resume,
-    diffRef: argv.diff,
+    diffRef: legacyDiff,
+    scopeMode,
+    diffBase,
+    failOnSeverity: argv.failOnSeverity as FailureSeverity | undefined,
     dashboard: argv.dashboard ?? false,
     showHelp: false,
     url: positionalArgs.url,
@@ -639,7 +703,7 @@ export async function runCli(
         return await runAutoConfigCommand(dependencies, parsedArgs);
 
       case 'run':
-        return await runRunCommand(parsedArgs, dependencies);
+        return await runRunCommandWithPreferences(parsedArgs, dependencies);
 
       case 'findings':
       case 'baselines':
@@ -932,9 +996,94 @@ async function runBenchmarkCommand(
   );
 }
 
-async function runRunCommand(
+type StoredRunPreferences = Omit<CliPreferences, 'version'>;
+
+function explicitRunPreferences(parsedArgs: ParsedCliArgs): StoredRunPreferences {
+  return {
+    ...(parsedArgs.provider ? { provider: parsedArgs.provider } : {}),
+    ...(parsedArgs.preset ? { preset: parsedArgs.preset } : {}),
+    ...(parsedArgs.focusModes ? { focusModes: parsedArgs.focusModes } : {}),
+    ...(parsedArgs.formats ? { formats: parsedArgs.formats } : {}),
+    ...(parsedArgs.headless !== undefined ? { headless: parsedArgs.headless } : {}),
+    ...(parsedArgs.scopeMode ? { scopeMode: parsedArgs.scopeMode } : {}),
+    ...(parsedArgs.diffBase ? { diffBase: parsedArgs.diffBase } : {}),
+    ...(parsedArgs.failOnSeverity ? { failOnSeverity: parsedArgs.failOnSeverity } : {}),
+  };
+}
+
+function preferencesToConfigLayer(preferences: StoredRunPreferences): Record<string, unknown> {
+  const layer: Record<string, unknown> = {};
+
+  if (preferences.preset) layer.preset = preferences.preset;
+  if (preferences.provider) {
+    layer.models = resolveProviderDefaults(preferences.provider);
+  }
+  if (preferences.headless !== undefined) {
+    layer.browser = { headless: preferences.headless };
+  }
+  if (preferences.formats) {
+    layer.output = {
+      format: preferences.formats.length === 1 ? preferences.formats[0] : [...preferences.formats],
+    };
+  }
+  if (preferences.focusModes) {
+    layer.mission = { focusModes: [...preferences.focusModes] };
+    if (preferences.focusModes.includes('adversarial')) {
+      layer.adversarial = { enabled: true };
+    }
+    if (preferences.focusModes.includes('api')) {
+      layer.apiTesting = { enabled: true };
+    }
+  }
+  if (preferences.scopeMode) {
+    layer.diffAware = {
+      enabled: preferences.scopeMode === 'diff',
+      restrictToChanged: preferences.scopeMode === 'diff',
+      ...(preferences.diffBase ? { baseRef: preferences.diffBase } : {}),
+    };
+  }
+  if (preferences.failOnSeverity) {
+    layer.qualityGate = { failOnSeverity: preferences.failOnSeverity };
+  }
+
+  return layer;
+}
+
+function hasProperties(value: Record<string, unknown>): boolean {
+  return Object.keys(value).length > 0;
+}
+
+async function runRunCommandWithPreferences(
   parsedArgs: ParsedCliArgs,
   dependencies: CliDependencies
+): Promise<number> {
+  const loaded = dependencies.loadCliPreferences?.() ?? { version: 1 };
+  const { version: _version, ...storedPreferences } = loaded;
+  const explicitPreferences = explicitRunPreferences(parsedArgs);
+  const exitCode = await runRunCommand(
+    parsedArgs,
+    dependencies,
+    storedPreferences,
+    explicitPreferences
+  );
+
+  if (hasProperties(explicitPreferences) && dependencies.saveCliPreferences) {
+    try {
+      dependencies.saveCliPreferences({ ...storedPreferences, ...explicitPreferences });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      dependencies.error(`Warning: could not save CLI preferences: ${message}`);
+    }
+  }
+
+  return exitCode;
+}
+
+async function runRunCommand(
+  parsedArgs: ParsedCliArgs,
+  dependencies: CliDependencies,
+  storedPreferences: StoredRunPreferences,
+  explicitPreferences: StoredRunPreferences
 ): Promise<number> {
   let config: LoadedDramaturgeConfig;
 
@@ -951,28 +1100,59 @@ async function runRunCommand(
     const inlineArgs: InlineRunArgs = {
       url: parsedArgs.url,
       login: parsedArgs.login,
-      headless: parsedArgs.headless,
-      provider: parsedArgs.provider,
-      preset: parsedArgs.preset,
-      focusModes: parsedArgs.focusModes,
-      formats: parsedArgs.formats,
+      headless: parsedArgs.headless ?? storedPreferences.headless,
+      provider: parsedArgs.provider ?? storedPreferences.provider,
+      preset: parsedArgs.preset ?? storedPreferences.preset,
+      focusModes: parsedArgs.focusModes ?? storedPreferences.focusModes,
+      formats: parsedArgs.formats ?? storedPreferences.formats,
     };
     config = buildConfigFromArgs(inlineArgs);
+    const inlineSettings = { ...storedPreferences, ...explicitPreferences };
+    config = {
+      ...config,
+      ...(inlineSettings.scopeMode
+        ? {
+            diffAware: {
+              ...config.diffAware,
+              enabled: inlineSettings.scopeMode === 'diff',
+              restrictToChanged: inlineSettings.scopeMode === 'diff',
+              ...(inlineSettings.diffBase ? { baseRef: inlineSettings.diffBase } : {}),
+            },
+          }
+        : {}),
+      qualityGate: {
+        ...config.qualityGate,
+        failOnSeverity: inlineSettings.failOnSeverity ?? config.qualityGate.failOnSeverity,
+      },
+    };
   } else {
     // File mode: load config from file (existing behavior)
-    config = dependencies.loadConfig(parsedArgs.configPath);
-    if (parsedArgs.formats && parsedArgs.formats.length > 0) {
-      config = {
-        ...config,
-        output: {
-          ...config.output,
-          format: parsedArgs.formats.length === 1 ? parsedArgs.formats[0] : [...parsedArgs.formats],
-        },
-      };
-    }
+    const defaults = preferencesToConfigLayer(storedPreferences);
+    const overrides = preferencesToConfigLayer(explicitPreferences);
+    const loadOptions =
+      hasProperties(defaults) || hasProperties(overrides) ? { defaults, overrides } : undefined;
+    config = loadOptions
+      ? dependencies.loadConfig(parsedArgs.configPath, loadOptions)
+      : dependencies.loadConfig(parsedArgs.configPath);
+  }
+
+  if (
+    config.diffAware?.enabled &&
+    config.diffAware.restrictToChanged &&
+    !config.diffAware.baseRef
+  ) {
+    throw new Error('Diff scope requires --diff-base <ref> or diffAware.baseRef in project config');
   }
 
   const eventStream = new EngineEventEmitter();
+  const observedSeverities = emptySeverityCounts();
+  let finalSeverities: typeof observedSeverities | undefined;
+  eventStream.on('finding', (event) => {
+    observedSeverities[event.severity]++;
+  });
+  eventStream.on('run:end', (event) => {
+    finalSeverities = event.findingsBySeverity;
+  });
 
   let dashboardHandle: { cleanup: () => void; waitUntilExit: Promise<void> } | undefined;
 
@@ -987,7 +1167,7 @@ async function runRunCommand(
     await dependencies.runEngine(config, {
       resumeDir: resolveResumeDir(parsedArgs.resumeDir, config),
       eventStream,
-      diffRef: parsedArgs.diffRef,
+      diffRef: config.diffAware?.enabled ? config.diffAware.baseRef : undefined,
       profile: parsedArgs.profile,
     });
   } finally {
@@ -998,6 +1178,26 @@ async function runRunCommand(
       dashboardHandle.cleanup();
       await dashboardHandle.waitUntilExit;
     }
+  }
+
+  const threshold =
+    parsedArgs.failOnSeverity ??
+    config.qualityGate?.failOnSeverity ??
+    storedPreferences.failOnSeverity ??
+    'major';
+  const severityCounts = finalSeverities ?? observedSeverities;
+  const failedCount = Object.entries(severityCounts).reduce(
+    (total, [severity, count]) =>
+      meetsSeverityThreshold(severity as keyof typeof severityCounts, threshold)
+        ? total + count
+        : total,
+    0
+  );
+  if (failedCount > 0) {
+    dependencies.error(
+      `Quality gate failed: ${failedCount} finding(s) met or exceeded the ${threshold} threshold.`
+    );
+    return 2;
   }
 
   return 0;

--- a/src/commands/auto-config.ts
+++ b/src/commands/auto-config.ts
@@ -605,6 +605,9 @@ function buildConfig(
       format: 'markdown',
       screenshots: true,
     },
+    qualityGate: {
+      failOnSeverity: 'major',
+    },
     browser: {
       headless: answers.headless,
     },

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -34,6 +34,9 @@ function buildMinimalConfig(targetUrl: string): string {
         format: 'markdown',
         screenshots: true,
       },
+      qualityGate: {
+        failOnSeverity: 'major',
+      },
       browser: {
         headless: false,
       },
@@ -107,6 +110,9 @@ function buildFullConfig(targetUrl: string): string {
         dir: './dramaturge-reports',
         format: 'markdown',
         screenshots: true,
+      },
+      qualityGate: {
+        failOnSeverity: 'major',
       },
       memory: {
         enabled: true,

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -235,6 +235,9 @@ export async function runSetup(deps: SetupDependencies, args: SetupArgs = {}): P
       format: 'markdown',
       screenshots: true,
     },
+    qualityGate: {
+      failOnSeverity: 'major',
+    },
     browser: {
       headless,
     },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -769,6 +769,55 @@ describe('loadConfig', () => {
     });
     expect(effectiveReportDir).toBe(resolve(dir, 'ci-reports'));
   });
+
+  it('layers user defaults below project config and CLI overrides above it', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        targetUrl: 'https://example.com',
+        appDescription: 'Project config',
+        auth: { type: 'none' },
+        browser: { headless: false },
+        qualityGate: { failOnSeverity: 'minor' },
+      })
+    );
+
+    const loaded = loadConfig(configPath, {
+      defaults: {
+        preset: 'smoke',
+        browser: { headless: true },
+        qualityGate: { failOnSeverity: 'trivial' },
+      },
+      overrides: {
+        qualityGate: { failOnSeverity: 'critical' },
+      },
+    });
+
+    expect(loaded.browser.headless).toBe(false);
+    expect(loaded.budget.globalTimeLimitSeconds).toBe(180);
+    expect(loaded.qualityGate.failOnSeverity).toBe('critical');
+  });
+
+  it('defaults the run quality gate to major and accepts an explicit opt-out', () => {
+    const dir = createTempDir();
+    const configPath = join(dir, 'dramaturge.config.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        targetUrl: 'https://example.com',
+        appDescription: 'Quality gate defaults',
+        auth: { type: 'none' },
+      })
+    );
+
+    expect(loadConfig(configPath).qualityGate.failOnSeverity).toBe('major');
+    const disabled = loadConfig(configPath, {
+      overrides: { qualityGate: { failOnSeverity: 'none' } },
+    });
+    expect(disabled.qualityGate.failOnSeverity).toBe('none');
+  });
 });
 
 describe('resolveOutputFormats', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ import {
   BOOTSTRAP_POLL_INTERVAL_MS,
 } from './constants.js';
 import { PRESET_NAMES, buildPreset, isPresetName } from './presets.js';
+import { FAILURE_SEVERITIES } from './severity.js';
 
 /**
  * Zod schema for a model string that rejects unknown provider prefixes (#224).
@@ -714,6 +715,16 @@ const ExperimentalSchema = z
     workflowAutomata: WorkflowAutomataSchema.parse({}),
   }));
 
+const QualityGateSchema = z
+  .object({
+    /** Make `dramaturge run` fail when a finding meets this severity threshold. */
+    failOnSeverity: z.enum(FAILURE_SEVERITIES).default('major'),
+  })
+  .strict()
+  .default({
+    failOnSeverity: 'major',
+  });
+
 export const ConfigSchema = z
   .object({
     targetUrl: z.string().url(),
@@ -745,6 +756,7 @@ export const ConfigSchema = z
     policy: PolicySchema,
     a2a: A2ASchema,
     experimental: ExperimentalSchema,
+    qualityGate: QualityGateSchema,
   })
   .strict();
 
@@ -755,6 +767,7 @@ export type AdversarialConfig = z.infer<typeof AdversarialSchema>;
 export type JudgeConfig = z.infer<typeof JudgeSchema>;
 export type VisionAnalysisConfig = z.infer<typeof VisionAnalysisSchema>;
 export type WorkflowAutomataConfig = z.infer<typeof WorkflowAutomataSchema>;
+export type QualityGateConfig = z.infer<typeof QualityGateSchema>;
 export type { ConfigFileContext, LoadedConfigMeta } from './config-paths.js';
 export type AuthConfig = z.infer<typeof AuthConfigSchema>;
 export type AuthProfiles = z.infer<typeof AuthProfilesSchema>;
@@ -959,7 +972,22 @@ export function applyConfigPreset(raw: unknown): unknown {
   return deepMergeConfig(presetConfig, rest);
 }
 
-export function loadConfig(configPath?: string): LoadedDramaturgeConfig {
+export interface LoadConfigOptions {
+  /** Lowest-precedence, non-secret user defaults. */
+  defaults?: Record<string, unknown>;
+  /** Highest-precedence explicit CLI overrides. */
+  overrides?: Record<string, unknown>;
+}
+
+function resolveConfigLayer(raw: unknown): Record<string, unknown> {
+  const resolved = applyConfigPreset(raw);
+  return isPlainObject(resolved) ? resolved : {};
+}
+
+export function loadConfig(
+  configPath?: string,
+  options: LoadConfigOptions = {}
+): LoadedDramaturgeConfig {
   const context = getConfigFileContext(configPath);
   let raw: string;
   try {
@@ -977,7 +1005,10 @@ export function loadConfig(configPath?: string): LoadedDramaturgeConfig {
 
   let presetApplied: unknown;
   try {
-    presetApplied = applyConfigPreset(parsed);
+    const defaults = resolveConfigLayer(options.defaults ?? {});
+    const project = resolveConfigLayer(parsed);
+    const overrides = resolveConfigLayer(options.overrides ?? {});
+    presetApplied = deepMergeConfig(deepMergeConfig(defaults, project), overrides);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Invalid config file: ${context.configPath}\n${message}`, { cause: error });

--- a/src/engine/event-stream.ts
+++ b/src/engine/event-stream.ts
@@ -18,6 +18,8 @@ export interface RunEndEvent {
   timestamp: string;
   tasksExecuted: number;
   totalFindings: number;
+  /** Deduplicated report findings grouped by severity. */
+  findingsBySeverity?: Record<FindingSeverity, number>;
   statesDiscovered: number;
   blindSpots: number;
   durationMs: number;

--- a/src/engine/finalize-run.ts
+++ b/src/engine/finalize-run.ts
@@ -10,6 +10,7 @@ import { emitEngineEvent } from './event-stream.js';
 import { buildAreaResults, writeReports } from './reports.js';
 import { finalizeWorkflowAutomata } from '../workflow-automata/planner-adapter.js';
 import { BLIND_SPOT_HIGH_PRIORITY_THRESHOLD } from '../constants.js';
+import { emptySeverityCounts } from '../severity.js';
 
 export interface FinalizeRunOptions {
   startTime: Date;
@@ -88,13 +89,16 @@ export async function finalizeRun(ctx: EngineContext, options: FinalizeRunOption
   await writeReports(ctx, startTime, areaResults, remaining);
 
   const blindSpots = ctx.globalCoverage.getBlindSpots();
-  const totalFindings = [...ctx.findingsByNode.values()].reduce(
-    (sum, findings) => sum + findings.length,
-    0
-  );
+  const findings = collectFindings(areaResults);
+  const findingsBySeverity = emptySeverityCounts();
+  for (const finding of findings) {
+    findingsBySeverity[finding.severity]++;
+  }
+  const totalFindings = findings.length;
   ctx.logger?.info('Run complete', {
     tasksExecuted,
     totalFindings,
+    findingsBySeverity,
     statesDiscovered: ctx.graph.nodeCount(),
     blindSpots: blindSpots.length,
     durationMs: Date.now() - startTime.getTime(),
@@ -104,6 +108,7 @@ export async function finalizeRun(ctx: EngineContext, options: FinalizeRunOption
     timestamp: new Date().toISOString(),
     tasksExecuted,
     totalFindings,
+    findingsBySeverity,
     statesDiscovered: ctx.graph.nodeCount(),
     blindSpots: blindSpots.length,
     durationMs: Date.now() - startTime.getTime(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,8 @@ export type {
   DramaturgeConfig,
   LoadedDramaturgeConfig,
   WorkflowAutomataConfig,
+  LoadConfigOptions,
+  QualityGateConfig,
 } from './config.js';
 export { PRESET_NAMES, buildPreset, isPresetName } from './presets.js';
 export type { PresetName } from './presets.js';

--- a/src/report/collector.test.ts
+++ b/src/report/collector.test.ts
@@ -68,6 +68,22 @@ describe('collectFindings', () => {
     ]);
   });
 
+  it('promotes grouped finding severity to the highest observed severity', () => {
+    const area1 = makeAreaResult('page A', [makeFinding('Minor', 'Bug', 'Shared severity issue')]);
+    const area2 = makeAreaResult('page B', [
+      makeFinding('Critical', 'Bug', 'Shared severity issue'),
+    ]);
+
+    const result = collectFindings([area1, area2]);
+    expect(result).toHaveLength(1);
+    expect(result[0].severity).toBe('Critical');
+    expect(result[0].occurrenceCount).toBe(2);
+    expect(result[0].occurrences.map((occurrence) => occurrence.area)).toEqual([
+      'page A',
+      'page B',
+    ]);
+  });
+
   it('re-numbers IDs after sorting', () => {
     const area = makeAreaResult('test', [
       makeFinding('Minor', 'Bug', 'minor'),

--- a/src/report/collector.ts
+++ b/src/report/collector.ts
@@ -120,6 +120,9 @@ function mergeExistingFinding(
   occurrence: FindingOccurrence
 ): void {
   existing.occurrences.push(occurrence);
+  if (SEVERITY_ORDER[raw.severity] < SEVERITY_ORDER[existing.severity]) {
+    existing.severity = raw.severity;
+  }
   existing.impactedAreas = Array.from(new Set([...existing.impactedAreas, occurrence.area]));
   existing.occurrenceCount = existing.occurrences.length;
   existing.evidenceIds = Array.from(

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -51,6 +51,10 @@ function renderHeader(
     `**Duration:** ${formatDuration(duration)} | **Areas explored:** ${exploredAreas.length} | **Total steps:** ${totalSteps}`
   );
   lines.push('');
+  lines.push(
+    '> Findings are evidence-backed observations with reproduction context. When live replay validation is enabled, each validation outcome is shown on the finding.'
+  );
+  lines.push('');
   return lines;
 }
 

--- a/src/report/markdown.ts
+++ b/src/report/markdown.ts
@@ -52,7 +52,7 @@ function renderHeader(
   );
   lines.push('');
   lines.push(
-    '> Findings are evidence-backed observations with reproduction context. When live replay validation is enabled, each validation outcome is shown on the finding.'
+    '> Findings may include evidence and reproduction context. When live replay validation is enabled, each validation outcome is shown on the finding.'
   );
   lines.push('');
   return lines;

--- a/src/severity.test.ts
+++ b/src/severity.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import { describe, expect, it } from 'vitest';
+import { emptySeverityCounts, meetsSeverityThreshold, toFindingSeverity } from './severity.js';
+
+describe('severity helpers', () => {
+  it('normalizes CLI thresholds to finding severities', () => {
+    expect(toFindingSeverity('critical')).toBe('Critical');
+    expect(toFindingSeverity('trivial')).toBe('Trivial');
+  });
+
+  it('matches findings at or above a threshold', () => {
+    expect(meetsSeverityThreshold('Critical', 'major')).toBe(true);
+    expect(meetsSeverityThreshold('Major', 'major')).toBe(true);
+    expect(meetsSeverityThreshold('Minor', 'major')).toBe(false);
+    expect(meetsSeverityThreshold('Critical', 'none')).toBe(false);
+  });
+
+  it('creates independent zeroed severity counts', () => {
+    const counts = emptySeverityCounts();
+    counts.Critical++;
+    expect(emptySeverityCounts().Critical).toBe(0);
+  });
+});

--- a/src/severity.ts
+++ b/src/severity.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Alex Rambasek
+
+import type { FindingSeverity } from './types.js';
+
+export const FAILURE_SEVERITIES = ['critical', 'major', 'minor', 'trivial', 'none'] as const;
+
+export type FailureSeverity = (typeof FAILURE_SEVERITIES)[number];
+
+export const FINDING_SEVERITIES: FindingSeverity[] = ['Critical', 'Major', 'Minor', 'Trivial'];
+
+const SEVERITY_RANK: Record<FindingSeverity, number> = {
+  Critical: 0,
+  Major: 1,
+  Minor: 2,
+  Trivial: 3,
+};
+
+export function toFindingSeverity(value: Exclude<FailureSeverity, 'none'>): FindingSeverity {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}` as FindingSeverity;
+}
+
+export function meetsSeverityThreshold(
+  severity: FindingSeverity,
+  threshold: FailureSeverity
+): boolean {
+  if (threshold === 'none') return false;
+  return SEVERITY_RANK[severity] <= SEVERITY_RANK[toFindingSeverity(threshold)];
+}
+
+export function emptySeverityCounts(): Record<FindingSeverity, number> {
+  return {
+    Critical: 0,
+    Major: 0,
+    Minor: 0,
+    Trivial: 0,
+  };
+}

--- a/src/yargs.d.ts
+++ b/src/yargs.d.ts
@@ -7,6 +7,9 @@ declare module 'yargs' {
     config?: string;
     resume?: string;
     diff?: string;
+    scopeMode?: string;
+    diffBase?: string;
+    failOnSeverity?: string;
     dashboard?: boolean;
     login?: boolean;
     headless?: boolean;


### PR DESCRIPTION
## Summary

- add first-class diff-scoped runs with `--scope-mode diff --diff-base`, preserving `--diff`
- persist safe CLI preferences with CLI > project > user > built-in precedence
- add configurable run quality gates and documented exit codes
- auto-scope GitHub Action pull-request runs to their base diff
- strengthen evidence-backed finding, regression promotion, and multi-agent positioning

Autofix/patch-PR generation is intentionally deferred.

## Verification

- `pnpm run test` (146 files, 1,447 tests)
- `pnpm run build`
- `pnpm run lint` (passes with existing warnings)
- `pnpm run pack:check`
- modified-file Prettier checks
- Action YAML and example configs parsed successfully